### PR TITLE
feat: track last applied time for profile tie-breaks

### DIFF
--- a/src/monique/app.py
+++ b/src/monique/app.py
@@ -81,7 +81,6 @@ def _cmd_switch_profile(name: str) -> int:
         use_description=not settings.get("use_port_names", False),
     )
     save_active_profile(name)
-    
     profile.last_applied_time = time.time()
     mgr.save(profile)
 

--- a/src/monique/app.py
+++ b/src/monique/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 
 import gi
 gi.require_version("Gtk", "4.0")
@@ -80,6 +81,10 @@ def _cmd_switch_profile(name: str) -> int:
         use_description=not settings.get("use_port_names", False),
     )
     save_active_profile(name)
+    
+    profile.last_applied_time = time.time()
+    mgr.save(profile)
+
     print(name)
     return 0
 

--- a/src/monique/daemon.py
+++ b/src/monique/daemon.py
@@ -299,6 +299,8 @@ class MonitorDaemon:
                     profile, update_sddm=update_sddm,
                     update_greetd=update_greetd, use_description=use_desc,
                 )
+                profile.last_applied_time = time.time()
+                self._profile_mgr.save(profile)
                 self._last_apply_time = time.monotonic()
                 self._prev_applied_profile = self._last_applied_profile
                 self._last_applied_profile = profile.name

--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -1019,7 +1019,7 @@ class Profile:
     name: str = ""
     monitors: list[MonitorConfig] = field(default_factory=list)
     workspace_rules: list[WorkspaceRule] = field(default_factory=list)
-    last_applied_time: float = 0
+    last_applied_time: float = 0.0
 
     @property
     def fingerprint(self) -> list[str]:
@@ -1031,7 +1031,7 @@ class Profile:
             "name": self.name,
             "monitors": [m.to_dict() for m in self.monitors],
             "workspace_rules": [w.to_dict() for w in self.workspace_rules],
-            "last_applied_time": self.last_applied_time
+            "last_applied_time": self.last_applied_time,
         }
 
     @classmethod
@@ -1040,7 +1040,7 @@ class Profile:
             name=d.get("name", ""),
             monitors=[MonitorConfig.from_dict(m) for m in d.get("monitors", [])],
             workspace_rules=[WorkspaceRule.from_dict(w) for w in d.get("workspace_rules", [])],
-            last_applied_time=d.get("last_applied_time", 0)
+            last_applied_time=d.get("last_applied_time", 0.0),
         )
 
     def generate_config(self, use_description: bool = False, use_v2: bool = False) -> str:

--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -1019,6 +1019,7 @@ class Profile:
     name: str = ""
     monitors: list[MonitorConfig] = field(default_factory=list)
     workspace_rules: list[WorkspaceRule] = field(default_factory=list)
+    last_applied_time: float = 0
 
     @property
     def fingerprint(self) -> list[str]:
@@ -1030,6 +1031,7 @@ class Profile:
             "name": self.name,
             "monitors": [m.to_dict() for m in self.monitors],
             "workspace_rules": [w.to_dict() for w in self.workspace_rules],
+            "last_applied_time": self.last_applied_time
         }
 
     @classmethod
@@ -1038,6 +1040,7 @@ class Profile:
             name=d.get("name", ""),
             monitors=[MonitorConfig.from_dict(m) for m in d.get("monitors", [])],
             workspace_rules=[WorkspaceRule.from_dict(w) for w in d.get("workspace_rules", [])],
+            last_applied_time=d.get("last_applied_time", 0)
         )
 
     def generate_config(self, use_description: bool = False, use_v2: bool = False) -> str:

--- a/src/monique/profile_manager.py
+++ b/src/monique/profile_manager.py
@@ -152,5 +152,7 @@ class ProfileManager:
 
         # Best Jaccard, fewest missing enabled, most external enabled,
         # most enabled matches, most config matches, latest applied profile time
+        # last_applied_time is a tiebreaker to prefer the most recently used profile
+        # among equally good matches
         candidates.sort(key=lambda c: (c[0], c[1], c[2], c[3], c[4], c[5]), reverse=True)
         return candidates[0][6]

--- a/src/monique/profile_manager.py
+++ b/src/monique/profile_manager.py
@@ -144,13 +144,13 @@ class ProfileManager:
 
             candidates.append((
                 score, -missing_enabled, ext_enabled,
-                enabled_matches, config_matches, profile,
+                enabled_matches, config_matches, profile.last_applied_time, profile,
             ))
 
         if not candidates:
             return None
 
         # Best Jaccard, fewest missing enabled, most external enabled,
-        # most enabled matches, most config matches
-        candidates.sort(key=lambda c: (c[0], c[1], c[2], c[3], c[4]), reverse=True)
-        return candidates[0][5]
+        # most enabled matches, most config matches, latest applied profile time
+        candidates.sort(key=lambda c: (c[0], c[1], c[2], c[3], c[4], c[5]), reverse=True)
+        return candidates[0][6]

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -696,6 +696,7 @@ class MainWindow(Adw.ApplicationWindow):
                 self._base_profile_name = match.name
                 self._workspace_rules = match.workspace_rules
                 self._inhibit_profile_switch = False
+                self._last_applied_time = match.last_applied_time
                 break
 
     def _select_profile_by_name(self, name: str) -> None:
@@ -885,6 +886,7 @@ class MainWindow(Adw.ApplicationWindow):
     def _mark_dirty(self) -> None:
         """Switch dropdown to (Current) when the user modifies anything."""
         self._dirty = True
+        self._last_applied_time = 0.0 # reset last applied time as config has changed
         if self._inhibit_profile_switch:
             return
         sel = self._profile_dropdown.get_selected()

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -29,6 +29,7 @@ from .utils import (
 
 import os
 from pathlib import Path
+import time
 
 
 def _detect_ipc() -> HyprlandIPC | NiriIPC | SwayIPC:
@@ -168,6 +169,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._dirty: bool = False
         self._lid_closed: bool = False
         self._app_settings = load_app_settings()
+        self._last_applied_time: float = 0
 
         self._build_ui()
         self._setup_actions()
@@ -723,6 +725,7 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_profile_selected(self, dropdown: Gtk.DropDown, pspec) -> None:
         if self._inhibit_profile_switch:
             return
+        self._last_applied_time = 0
         sel = dropdown.get_selected()
         if sel == 0:
             # Current = reload from Hyprland
@@ -738,6 +741,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._current_profile_name = profile.name
             self._base_profile_name = profile.name
             self._canvas.monitors = self._monitors
+            self._last_applied_time = profile.last_applied_time
             if self._monitors:
                 self._canvas.selected_index = 0
                 self._update_properties_for_selected()
@@ -841,6 +845,7 @@ class MainWindow(Adw.ApplicationWindow):
             name=name,
             monitors=list(self._monitors),
             workspace_rules=list(self._workspace_rules),
+            last_applied_time=self._last_applied_time
         )
         self._profile_mgr.save(profile)
         self._current_profile_name = name
@@ -1041,6 +1046,12 @@ class MainWindow(Adw.ApplicationWindow):
                 bak.unlink()
             self._migrated_workspaces = []
             self._base_profile_name = self._current_profile_name
+            self._last_applied_time = time.time()
+            # update profile's last applied time if applicable
+            # if its edited, then its no longer a named profile enforced by mark dirty
+            if profile := self._profile_mgr.load(self._base_profile_name):
+                profile.last_applied_time = self._last_applied_time
+                self._profile_mgr.save(profile)
             save_active_profile(self._current_profile_name or None)
             self._toast("Settings kept")
         else:

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -169,7 +169,8 @@ class MainWindow(Adw.ApplicationWindow):
         self._dirty: bool = False
         self._lid_closed: bool = False
         self._app_settings = load_app_settings()
-        self._last_applied_time: float = 0
+        # time of last successful application of curr config (0 = never applied since change)
+        self._last_applied_time: float = 0.0
 
         self._build_ui()
         self._setup_actions()
@@ -725,7 +726,7 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_profile_selected(self, dropdown: Gtk.DropDown, pspec) -> None:
         if self._inhibit_profile_switch:
             return
-        self._last_applied_time = 0
+        self._last_applied_time = 0.0
         sel = dropdown.get_selected()
         if sel == 0:
             # Current = reload from Hyprland
@@ -845,7 +846,7 @@ class MainWindow(Adw.ApplicationWindow):
             name=name,
             monitors=list(self._monitors),
             workspace_rules=list(self._workspace_rules),
-            last_applied_time=self._last_applied_time
+            last_applied_time=self._last_applied_time,
         )
         self._profile_mgr.save(profile)
         self._current_profile_name = name


### PR DESCRIPTION
Fixes #13 

Currently, the `find_best_match` function does not have a way to handle tie-breaks when multiple profiles return identical rankings. This leads to inconsistent prioritization where certain profiles may be repeatedly selected over others, even if they were the most recently applied.

To ensure fair and logical behavior, an additional `last_applied_time` field is introduced. This tracks the last time a profile was applied and serves as a secondary sorting mechanism. By using this timestamp to handle tie-breaks, the system can deterministically prioritize the most recently utilized profile in the above scenario.

This field as of now is updated via the following:
- `monique` cli `--switch-profile`
- successful application of a **named** profile from within `monique`** GUI 
- saving a new/edited profile that was applied successfully

If there is no such field / not applied before, `last_applied_time` will be defaulted to 0 which fallsback to the old sorting behavior