### PR TITLE
fix: read missing values from different IPCs in `from_xxx()`

### DIFF
--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -591,6 +591,11 @@ class MonitorConfig:
             transform=Transform(data.get("transform", 0)),
             enabled=not disabled,
             vrr=vrr_val,
+            color_management=data.get("colorManagementPreset", ""),
+            sdr_brightness=data.get("sdrBrightness", 1.0),
+            sdr_saturation=data.get("sdrSaturation", 1.0),
+            sdr_min_luminance=data.get("sdrMinLuminance", 0.0),
+            sdr_max_luminance=data.get("sdrMaxLuminance", 0.0),
         )
 
     @classmethod


### PR DESCRIPTION
Partially fixes #23

This fix adds the related fields that ARE available via compositor IPC

**Hyprland/Hyprctl**
- colorManagementPreset -> color_management
- sdrBrightness -> sdr_brightness
- sdrSaturation -> sdr_saturation
- sdrMinLuminance -> sdr_min_luminance
- sdrMaxLuminance -> sdr_max_luminance

#### Progress
- [x] Hyprland (from_hyprctl) - Fixed
- [ ] ~~Sway (from_sway_output) - Needs investigation~~
- [ ] ~~Niri (from_niri_output) - Needs investigation~~
