### PR TITLE
feat: Track profile modifications with *

### DIFF
--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -954,12 +954,7 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             monitors_conf = hyprland_config_dir() / "monitors.conf"
 
-        # Snapshot actual compositor state before applying (for revert)
-        pre_monitors = self._ipc.get_monitors()
-        self._place_disabled(pre_monitors)
-        self._pre_apply_monitors = pre_monitors
-        self._pre_apply_profile_name = self._base_profile_name
-        self._pre_apply_workspace_rules = list(self._workspace_rules)
+        # Snapshot workspaces (for revert)
         self._ws_snapshot = self._ipc.get_workspaces()
         self._migrated_workspaces: list[tuple[str, str]] = []
 
@@ -1076,18 +1071,9 @@ class MainWindow(Adw.ApplicationWindow):
                 self._toast(f"Revert reload failed: {e}")
                 return
 
-            # Restore pre-apply GUI state directly (no need to re-query compositor)
-            self._monitors = self._pre_apply_monitors
-            self._current_profile_name = self._pre_apply_profile_name
-            self._workspace_rules = self._pre_apply_workspace_rules
-            self._canvas.monitors = self._monitors
-            if self._monitors:
-                self._canvas.selected_index = 0
-                self._update_properties_for_selected()
-            self._update_clamshell_indicators()
-            # Select the pre-apply profile in dropdown by name
-            self._select_profile_by_name(self._pre_apply_profile_name)
-            self._toast("Settings reverted")
+            # Backup restored; GUI left untouched to avoid disrupting user's current
+            # editing/viewing session
+            self._toast("Configuration restored from backup")
         else:
             self._toast("No backup to revert")
 

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -168,6 +168,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._inhibit_profile_switch: bool = False
         self._osd: MonitorOSD | None = None
         self._dirty: bool = False
+        self._current_modified_profile: Profile | None = None
         self._lid_closed: bool = False
         self._app_settings = load_app_settings()
         # time of last successful application of curr config (0 = never applied since change)
@@ -641,6 +642,7 @@ class MainWindow(Adw.ApplicationWindow):
                 parts.append(f"{n_disabled} disabled")
             self._set_status(f"{len(self._monitors)} monitor(s) detected ({', '.join(parts)})")
             self._update_clamshell_indicators()
+            self._current_profile_name = ""
             if select_profile:
                 self._select_matching_profile()
         except Exception as e:
@@ -734,34 +736,54 @@ class MainWindow(Adw.ApplicationWindow):
     def _refresh_profile_list(self) -> None:
         names = self._profile_mgr.list_profiles()
         options = ["(Current)"] + names
+        if self._dirty:
+            insertion_index = 1 # insert after "(Current) by default"
+            if self._current_profile_name in names:
+                insertion_index = options.index(self._current_profile_name) + 1
+            options.insert(insertion_index, self._current_modified_profile.name)
         self._profile_dropdown.set_model(Gtk.StringList.new(options))
         self._profile_dropdown.set_selected(0)
 
     def _on_profile_selected(self, dropdown: Gtk.DropDown, pspec) -> None:
         if self._inhibit_profile_switch:
             return
-        self._last_applied_time = 0.0
-        sel = dropdown.get_selected()
-        if sel == 0:
-            # Current = reload from Hyprland
-            self._load_current_state()
-            return
-        model = dropdown.get_model()
-        name = model.get_string(sel)
-        profile = self._profile_mgr.load(name)
-        if profile:
-            self._monitors = profile.monitors
-            self._place_disabled(self._monitors)
-            self._workspace_rules = profile.workspace_rules
-            self._current_profile_name = profile.name
-            self._base_profile_name = profile.name
-            self._canvas.monitors = self._monitors
-            self._last_applied_time = profile.last_applied_time
-            if self._monitors:
-                self._canvas.selected_index = 0
-                self._update_properties_for_selected()
-            self._update_clamshell_indicators()
-            self._set_status(f"Loaded profile: {name}")
+
+        def switch_to_selected():
+            sel = dropdown.get_selected()
+            self._last_applied_time = 0.0
+            self._dirty = False
+            self._current_modified_profile = None
+            if sel == 0:
+                self._load_current_state()
+                return
+            model = dropdown.get_model()
+            name = model.get_string(sel)
+            profile = self._profile_mgr.load(name)
+            if profile:
+                self._load_profile(profile)
+
+        def on_cancel(*_):
+            self._dirty = True # Enforce dirty to let us stay on the unsaved profile
+            return self._select_profile_by_name(self._current_modified_profile.name)
+
+        def remove_modified_profile(*_):
+            # update dropdown list to remove modified profile
+            new_profile = dropdown.get_selected_item().get_string()
+            self._inhibit_profile_switch = True
+            self._refresh_profile_list()
+            self._select_profile_by_name(new_profile)
+            self._inhibit_profile_switch = False
+            switch_to_selected()
+
+        if self._dirty:
+            # disables switching to saved profile if user saved the modification
+            self._on_switch_profile_request(
+                on_save=lambda: self._on_save_clicked(None, cancel_cb=on_cancel, success_cb=remove_modified_profile),
+                on_cancel=on_cancel,
+                on_discard=remove_modified_profile,
+            )
+        else:
+            switch_to_selected()
 
     def _on_save_clicked(self, btn, success_cb: Callable[[Profile], None] | None = None, cancel_cb: Callable | None = None) -> None:
         dialog = Adw.AlertDialog()
@@ -876,20 +898,11 @@ class MainWindow(Adw.ApplicationWindow):
                 cancel_cb()
             return
         self._dirty = False
+        self._current_modified_profile = None
         self._toast(f"Profile '{name}' saved")
         if success_cb:
             success_cb(profile)
 
-    def _on_delete_profile_clicked(self, btn) -> None:
-        sel = self._profile_dropdown.get_selected()
-        if sel == 0:
-            self._toast("Cannot delete (Current)")
-            return
-        model = self._profile_dropdown.get_model()
-        name = model.get_string(sel)
-        self._profile_mgr.delete(name)
-        self._refresh_profile_list()
-        self._toast(f"Profile '{name}' deleted")
 
     def _save_then_switch_saved_profile(self, btn) -> None:
         def after_save(profile: Profile) -> None:
@@ -897,9 +910,29 @@ class MainWindow(Adw.ApplicationWindow):
             self._current_profile_name = name
             self._inhibit_profile_switch = True
             self._refresh_profile_list()
+            # Select the saved profile in the dropdown
             self._select_profile_by_name(name)
             self._inhibit_profile_switch = False
         self._on_save_clicked(btn, success_cb=after_save)
+
+
+    def _on_delete_profile_clicked(self, btn) -> None:
+        sel = self._profile_dropdown.get_selected()
+        if sel == 0:
+            self._toast("Cannot delete (Current)")
+            return
+        if self._dirty:
+            # Discard changes
+            self._toast("Discarding changes")
+            self._dirty = False
+            self._current_modified_profile = None
+            self._refresh_profile_list()
+            return
+        model = self._profile_dropdown.get_model()
+        name = model.get_string(sel)
+        self._profile_mgr.delete(name)
+        self._refresh_profile_list()
+        self._toast(f"Profile '{name}' deleted")
 
     def _generate_profile_name(self) -> str:
         """Generate a default profile name from connected monitors."""
@@ -912,16 +945,20 @@ class MainWindow(Adw.ApplicationWindow):
 
     def _mark_dirty(self) -> None:
         """Switch dropdown to (Current) when the user modifies anything."""
-        self._dirty = True
         self._last_applied_time = 0.0 # reset last applied time as config has changed
-        if self._inhibit_profile_switch:
+        if self._dirty:
             return
-        sel = self._profile_dropdown.get_selected()
-        if sel != 0:
-            self._inhibit_profile_switch = True
-            self._profile_dropdown.set_selected(0)
-            self._inhibit_profile_switch = False
-        self._current_profile_name = ""
+        
+        self._dirty = True
+        self._current_modified_profile = Profile(
+            name=self._profile_dropdown.get_model().get_string(self._profile_dropdown.get_selected()) + "*",
+            monitors=list(self._monitors),
+            workspace_rules=list(self._workspace_rules),
+        )
+        self._inhibit_profile_switch = True
+        self._refresh_profile_list()
+        self._inhibit_profile_switch = False
+        self._select_profile_by_name(self._current_modified_profile.name)
 
     # ── Canvas Events ────────────────────────────────────────────────
 
@@ -963,7 +1000,10 @@ class MainWindow(Adw.ApplicationWindow):
     # ── Detect ───────────────────────────────────────────────────────
 
     def _on_detect_clicked(self, btn) -> None:
-        self._load_current_state()
+        # switch to (Current) and invoke check unsaved changed items before
+        # loading from IPC to prevent losing unsaved changes without warning
+        self._profile_dropdown.set_selected(0)
+
 
     # ── Apply ────────────────────────────────────────────────────────
 
@@ -1146,13 +1186,16 @@ class MainWindow(Adw.ApplicationWindow):
         on_cancel: Callable | None = None,
         on_discard: Callable | None = None,
     ) -> bool:
-        """Check for unsaved changes and prompt user to save/discard/cancel."""
+        """If there are unsaved changes, show a dialog asking the user to save/discard/cancel
+        and return True and block the GUI action until user responds.\n
+        Otherwise return False indicating there are no unsaved changes."""
         if not self._dirty:
-            return False
-
+            return False  # Ignore if no unsaved changes
+    
         dialog = Adw.AlertDialog()
         dialog.set_heading("Unsaved Changes")
         dialog.set_body(body_text)
+
         dialog.add_response("discard", "Discard")
         dialog.set_response_appearance("discard", Adw.ResponseAppearance.DESTRUCTIVE)
         dialog.add_response("cancel", "Cancel")
@@ -1161,6 +1204,7 @@ class MainWindow(Adw.ApplicationWindow):
         dialog.set_default_response("save")
         dialog.set_close_response("cancel")
 
+        # Create handler with closures
         def on_response(_, response: str):
             if response == "cancel":
                 if on_cancel:
@@ -1170,20 +1214,32 @@ class MainWindow(Adw.ApplicationWindow):
                 if on_save:
                     on_save()
                 return
-            self._dirty = False
+            self._dirty = False  # No longer dirty since user chose to discard
             if on_discard:
                 on_discard()
-
         dialog.connect("response", on_response)
         dialog.present(self)
-        return True
+        return True  # block action until user responds
 
-    # ── Close ──────────────────────────────────────────────────────────
+    def _on_switch_profile_request(
+        self,
+        on_save: callable | None = None,
+        on_cancel: callable | None = None,
+        on_discard: callable | None = None,
+    ) -> bool:
+        return self._check_unsaved_changes(
+            "Save changes before switching profiles?",
+            on_save=on_save,
+            on_cancel=on_cancel,
+            on_discard=on_discard,
+        )
+
+    # ── Close ─────────────────────────────────────────────────────────
 
     def _on_close_request(self, window: Adw.ApplicationWindow) -> bool:
         def save_and_close():
             self._on_save_clicked(None, success_cb=lambda _: self.close())
-
+        
         return self._check_unsaved_changes(
             "Save changes before exiting?",
             on_save=save_and_close,

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -682,6 +682,21 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             self._props.update_from_monitor(None)
 
+    def _load_profile(self, profile: Profile) -> None:
+        """Load a profile into the UI."""
+        self._monitors = profile.monitors
+        self._place_disabled(self._monitors)
+        self._workspace_rules = profile.workspace_rules
+        self._current_profile_name = profile.name
+        self._base_profile_name = profile.name
+        self._canvas.monitors = self._monitors
+        self._last_applied_time = profile.last_applied_time
+        if self._monitors:
+            self._canvas.selected_index = 0
+            self._update_properties_for_selected()
+        self._update_clamshell_indicators()
+        self._set_status(f"Loaded profile: {profile.name}")
+
     def _select_matching_profile(self) -> None:
         """If the current monitor layout matches a saved profile, select it."""
         current_fp = sorted(m.description for m in self._monitors if m.description)
@@ -693,11 +708,8 @@ class MainWindow(Adw.ApplicationWindow):
             if model.get_string(i) == match.name:
                 self._inhibit_profile_switch = True
                 self._profile_dropdown.set_selected(i)
-                self._current_profile_name = match.name
-                self._base_profile_name = match.name
-                self._workspace_rules = match.workspace_rules
                 self._inhibit_profile_switch = False
-                self._last_applied_time = match.last_applied_time
+                self._load_profile(match)
                 break
 
     def _select_profile_by_name(self, name: str) -> None:

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -1139,15 +1139,20 @@ class MainWindow(Adw.ApplicationWindow):
                 return gdk_mon
         return None
 
-    # ── Close ─────────────────────────────────────────────────────────
-
-    def _on_close_request(self, window: Adw.ApplicationWindow) -> bool:
+    def _check_unsaved_changes(
+        self,
+        body_text: str,
+        on_save: Callable | None = None,
+        on_cancel: Callable | None = None,
+        on_discard: Callable | None = None,
+    ) -> bool:
+        """Check for unsaved changes and prompt user to save/discard/cancel."""
         if not self._dirty:
-            return False  # allow close
+            return False
 
         dialog = Adw.AlertDialog()
         dialog.set_heading("Unsaved Changes")
-        dialog.set_body("Save changes before closing?")
+        dialog.set_body(body_text)
         dialog.add_response("discard", "Discard")
         dialog.set_response_appearance("discard", Adw.ResponseAppearance.DESTRUCTIVE)
         dialog.add_response("cancel", "Cancel")
@@ -1155,20 +1160,35 @@ class MainWindow(Adw.ApplicationWindow):
         dialog.set_response_appearance("save", Adw.ResponseAppearance.SUGGESTED)
         dialog.set_default_response("save")
         dialog.set_close_response("cancel")
-        dialog.connect("response", self._on_close_dialog_response)
-        dialog.present(self)
-        return True  # block close for now
 
-    def _on_close_dialog_response(self, dialog: Adw.AlertDialog, response: str) -> None:
-        if response == "cancel":
-            return
-        if response == "save":
-            self._save_then_switch_saved_profile(None)
-            # Close after save dialog completes (dirty will be False)
-            return
-        # discard
-        self._dirty = False
-        self.close()
+        def on_response(_, response: str):
+            if response == "cancel":
+                if on_cancel:
+                    on_cancel()
+                return
+            if response == "save":
+                if on_save:
+                    on_save()
+                return
+            self._dirty = False
+            if on_discard:
+                on_discard()
+
+        dialog.connect("response", on_response)
+        dialog.present(self)
+        return True
+
+    # ── Close ──────────────────────────────────────────────────────────
+
+    def _on_close_request(self, window: Adw.ApplicationWindow) -> bool:
+        def save_and_close():
+            self._on_save_clicked(None, success_cb=lambda _: self.close())
+
+        return self._check_unsaved_changes(
+            "Save changes before exiting?",
+            on_save=save_and_close,
+            on_discard=self.close,
+        )
 
     # ── Helpers ──────────────────────────────────────────────────────
 

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -30,6 +30,7 @@ from .utils import (
 import os
 from pathlib import Path
 import time
+from typing import Callable
 
 
 def _detect_ipc() -> HyprlandIPC | NiriIPC | SwayIPC:
@@ -198,7 +199,7 @@ class MainWindow(Adw.ApplicationWindow):
 
         # Save button
         btn_save = Gtk.Button(icon_name="document-save-symbolic", tooltip_text="Save profile")
-        btn_save.connect("clicked", self._on_save_clicked)
+        btn_save.connect("clicked", self._save_then_switch_saved_profile)
         header.pack_start(btn_save)
 
         # Delete profile button
@@ -284,7 +285,7 @@ class MainWindow(Adw.ApplicationWindow):
         """Set up keyboard shortcuts."""
         # Ctrl+S -> save
         action_save = Gio.SimpleAction(name="save")
-        action_save.connect("activate", lambda *_: self._on_save_clicked(None))
+        action_save.connect("activate", lambda *_: self._save_then_switch_saved_profile(None))
         self.add_action(action_save)
 
         # Ctrl+R -> detect
@@ -750,7 +751,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._update_clamshell_indicators()
             self._set_status(f"Loaded profile: {name}")
 
-    def _on_save_clicked(self, btn) -> None:
+    def _on_save_clicked(self, btn, success_cb: Callable[[Profile], None] | None = None, cancel_cb: Callable | None = None) -> None:
         dialog = Adw.AlertDialog()
         dialog.set_heading("Save Profile")
         dialog.add_response("cancel", "Cancel")
@@ -818,15 +819,21 @@ class MainWindow(Adw.ApplicationWindow):
         self._save_entry.connect("changed", lambda e: self._save_radio_new.set_active(True))
 
         dialog.set_extra_child(box)
-        dialog.connect("response", self._on_save_response)
+        dialog.connect("response", lambda d, r: self._on_save_response(d, r, success_cb, cancel_cb))
         dialog.present(self)
 
     def _on_save_new_toggled(self, radio: Gtk.CheckButton) -> None:
         if radio.get_active():
             self._save_entry.grab_focus()
 
-    def _on_save_response(self, dialog: Adw.AlertDialog, response: str) -> None:
+    def _on_save_response(self, dialog: Adw.AlertDialog,
+                              response: str,
+                              success_cb: Callable[[Profile], None] | None = None,
+                              cancel_cb: Callable | None = None
+    ) -> None:
         if response != "save":
+            if cancel_cb:
+                cancel_cb()
             return
 
         # Determine selected name
@@ -849,19 +856,17 @@ class MainWindow(Adw.ApplicationWindow):
             workspace_rules=list(self._workspace_rules),
             last_applied_time=self._last_applied_time,
         )
-        self._profile_mgr.save(profile)
-        self._current_profile_name = name
-        self._inhibit_profile_switch = True
-        self._refresh_profile_list()
-        # Select the saved profile in the dropdown
-        model = self._profile_dropdown.get_model()
-        for i in range(model.get_n_items()):
-            if model.get_string(i) == name:
-                self._profile_dropdown.set_selected(i)
-                break
-        self._inhibit_profile_switch = False
+        try:
+            self._profile_mgr.save(profile)
+        except Exception as e:
+            self._toast(f"An error occurred while saving {name}: {e}")
+            if cancel_cb:
+                cancel_cb()
+            return
         self._dirty = False
         self._toast(f"Profile '{name}' saved")
+        if success_cb:
+            success_cb(profile)
 
     def _on_delete_profile_clicked(self, btn) -> None:
         sel = self._profile_dropdown.get_selected()
@@ -873,6 +878,16 @@ class MainWindow(Adw.ApplicationWindow):
         self._profile_mgr.delete(name)
         self._refresh_profile_list()
         self._toast(f"Profile '{name}' deleted")
+
+    def _save_then_switch_saved_profile(self, btn) -> None:
+        def after_save(profile: Profile) -> None:
+            name = profile.name
+            self._current_profile_name = name
+            self._inhibit_profile_switch = True
+            self._refresh_profile_list()
+            self._select_profile_by_name(name)
+            self._inhibit_profile_switch = False
+        self._on_save_clicked(btn, success_cb=after_save)
 
     def _generate_profile_name(self) -> str:
         """Generate a default profile name from connected monitors."""
@@ -1136,7 +1151,7 @@ class MainWindow(Adw.ApplicationWindow):
         if response == "cancel":
             return
         if response == "save":
-            self._on_save_clicked(None)
+            self._save_then_switch_saved_profile(None)
             # Close after save dialog completes (dirty will be False)
             return
         # discard


### PR DESCRIPTION
Closes #25

## Summary
Refactors profile management in Monique to better track unsaved modifications and improves the dialog system with callback-based flows.

Whenever the user modifies anything, if _dirty is not true, then Monique will now snapshot the current profile environment and named it as "XXX" + "\*". e.g. ("Profile A" => "Profile A\*") and append it to the relevant location in dropdown and switches to it.  This also applies to "(Current)" => "(Current)*". (latest commit)

When the user reverts, the old monitor.conf is reapplied but now the settings will not switch to the current reported one by IPC but keeping whatever the user was working on before. (first commit)

When the user tries to switch to a different profile with unsaved changes, it now prompts the user to save/discard/cancel their current    modified profile. Should they save or discard, the temporary snapshot will be discarded. 

As this PR contains multiple commits which includes refactors that can be more generalized, I suggest rebasing the commits instead of merging all the commits together if it is approved

## Changes and relevant bug fixes 

### 1. fix: Keep modifications instead of overwriting from IPC during revert
- Simplify revert logic - don't reload monitors from IPC, keep user's current GUI state
- Removes `pre_apply_monitors` tracking
- When user reverts, just reload compositor config instead of overwriting GUI state from IPC
- Resolves revert consistency between workspace and display config

### 2. refactor: Add callbacks to save dialog 
- Add `success_cb` and `cancel_cb` parameters to `_on_save_clicked()`
- Pass callbacks through to `_on_save_response()` 
- Call callbacks at appropriate times after save completes
- Add `_save_then_switch_saved_profile()` that uses success callback (this replaces the old `_on_save_clicked()`
- Main purpose is to facilitate future changes that will benefit through the implementation of callback

### 3. refactor: Extract `_load_profile` method 
- Extract profile loading logic into dedicated `_load_profile(Profile)` method
- Reduces code duplication in profile selection
- Main purpose is to facilitate future changes that will benefit through this
- Side effects: fixes a bug where upon initial load, a named profile is selected but the values are incorrectly loaded

### 4. refactor: Replace close dialog with callback-based unsaved changes check
- Add reusable `_check_unsaved_changes(body_text, on_save, on_cancel, on_discard)` function
- Uses callback pattern to enable more customizable function call
- Main purpose is to facilitate future changes that will benefit through the implemementation of callback
- Side effect: when user exits with unsaved changes, the program will now exit after the user saves successfully, before, the exit will be aborted and the GUI will switch to the newly saved profile

### 5. feat: Track modifications with * profile entry
- Create modified profile entry in dropdown with "*" suffix when user edits settings
- Better UX - modified profiles shown as separate entry, not switching to "(Current)"
- Update `_on_profile_selected()` to handle dirty state with save/discard/cancel prompts using callbacks
- Update `_load_current_state()` to reset profile name when loading current state
- When deleting profile, _toast now reads "Discarding changes" instead if the current profile is unsaved


___
### Overview of workflow modifed by this PR

Summary of Modified Flows
1. Save Profile Flow
- `_on_save_clicked(success_cb, cancel_cb)` → `_on_save_response()` → calls optional callbacks after save completes or fails
- Added `_save_then_switch_saved_profile()` that uses success_cb to select the saved profile (this imitates the old `_on_saved_clicked` behavior and is used to replace GUI save and ctrl+S
---
2. Dirty Tracking Flow
```
_mark_dirty()
├── Creates _current_modified_profile (name="SelectedName*")
├── _refresh_profile_list() → inserts "*" profile in dropdown
└── _select_profile_by_name() → selects it

Modified profile stores all current monitor and workspace config / snapshot current version
```
---
3. Profile Selection Flow
```
_on_profile_selected()
├── if dirty? 
│   ├── Yes → _on_switch_profile_request() → prompt save/discard/cancel
│   │         ├── save → _on_save_clicked() → remove_modified_profile() → switch_to_selected()
│   │         ├── discard → remove_modified_profile() → switch_to_selected()
│   │         └── cancel → revert to last profile
│   └── No → switch_to_selected()
│
└── switch_to_selected()
    ├── if (Current) → _load_current_state()
    └── if named profile → _load_profile()
```
---
4. Close/Switch Dialog Flow
Refactored general check unsaved change dialog function
```
_check_unsaved_changes(body_text, on_save, on_cancel, on_discard)
├── if not dirty → return False
└── shows dialog → on_response() calls appropriate callback
    ├── cancel → on_cancel()
    ├── save → on_save()
    └── discard → on_discard()
```
Using the above, these 2 additional functions are created one to handle when user closes Monique
and the other to handle when user switches profile when they have unsaved changes
```
_on_close_request() → _check_unsaved_changes(on_save=save_and_close, on_discard=close)
_on_switch_profile_request() → wrapper for profile switching
```
---
5. Profile Loading
Refactored to reduce code duplication and maintain consistency
```
_load_profile(profile)  ← extracted method
├── self._monitors = profile.monitors
├── self._workspace_rules = profile.workspace_rules  
├── self._current_profile_name = profile.name
├── self._canvas.monitors = ...
├── _update_properties_for_selected()
└── _update_clamshell_indicators()
```
Called by:
- `_select_matching_profile()`, this fixes the issue where named profile is not properly loaded on first launch of monique
- `switch_to_selected()` in `_on_profile_selected()`