### PR TITLE
feat: add Hyprland Lua monitor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 - **Clamshell mode** — disable the internal laptop display when external monitors are connected (manual toggle in the toolbar or automatic via daemon preferences); the daemon also monitors the lid state via UPower D-Bus
 - **Confirm-or-revert** — 10-second countdown after applying, auto-reverts if display is unusable
 - **CLI interface** — list, query, and switch profiles from the terminal (`--list-profiles`, `--current-profile`, `--switch-profile`), perfect for hotkey bindings
-- **Custom config directory** — write `monitors.conf` to a custom path instead of the compositor default (via Preferences or `--config-dir`)
+- **Custom config directory** — write generated monitor config files to a custom path instead of the compositor default (via Preferences or `--config-dir`)
 - **Active profile tracking** — the last applied profile is persisted across GUI, CLI, and daemon, queryable via `--current-profile`
 
 ## Installation
@@ -249,9 +249,12 @@ All configuration is stored in `~/.config/monique/`:
 ```
 
 Monitor config files are written to the compositor's config directory:
-- **Hyprland:** `~/.config/hypr/monitors.conf`
+- **Hyprland:** `~/.config/hypr/monitors.conf` and `~/.config/hypr/monitors.lua`
 - **Sway:** `~/.config/sway/monitors.conf`
 - **Niri:** `~/.config/niri/monitors.kdl`
+
+For Hyprland's legacy hyprlang config, add `source = ~/.config/hypr/monitors.conf` to `hyprland.conf`.
+For Hyprland 0.55+ Lua config, add `require("monitors")` to `hyprland.lua`.
 
 To use a custom output directory, set it in **Preferences → Config Output** or pass `--config-dir` on the command line.
 

--- a/src/monique/app.py
+++ b/src/monique/app.py
@@ -99,7 +99,7 @@ def main() -> None:
     parser.add_argument(
         "--config-dir",
         metavar="PATH",
-        help="Override output directory for monitors.conf",
+        help="Override output directory for generated monitor config files",
     )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(

--- a/src/monique/hyprland.py
+++ b/src/monique/hyprland.py
@@ -189,13 +189,18 @@ class HyprlandIPC:
         """Write monitor config and reload Hyprland."""
         conf_dir = hyprland_config_dir()
         monitors_conf = conf_dir / "monitors.conf"
+        monitors_lua = conf_dir / "monitors.lua"
 
         # Backup existing
         backup_file(monitors_conf)
+        backup_file(monitors_lua)
 
-        # Write new config (monitorv2 blocks for Hyprland >= 0.50)
+        # Write both legacy hyprlang and Hyprland >= 0.55 Lua configs.
         write_text(monitors_conf, profile.generate_config(
             use_description=use_description, use_v2=self.supports_v2,
+        ))
+        write_text(monitors_lua, profile.generate_lua_config(
+            use_description=use_description,
         ))
 
         # Also write Sway config if Sway is installed

--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -70,6 +70,32 @@ class Transform(Enum):
         return self.value in (1, 3, 5, 7)
 
 
+def _lua_string(value: str) -> str:
+    """Return *value* as a double-quoted Lua string literal."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+    return f'"{escaped}"'
+
+
+def _lua_scalar(value: bool | int | float | str) -> str:
+    """Render a simple Python value as a Lua literal."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        return f"{value:g}"
+    if isinstance(value, int):
+        return str(value)
+    return _lua_string(value)
+
+
+def _lua_field(name: str, value: bool | int | float | str, indent: int = 2) -> str:
+    return f"{' ' * indent}{name} = {_lua_scalar(value)},"
+
+
 # ── MonitorConfig ────────────────────────────────────────────────────────
 
 @dataclass
@@ -521,6 +547,94 @@ class MonitorConfig:
 
         return "monitorv2 {\n" + "\n".join(lines) + "\n}"
 
+    def to_hyprland_lua_block(
+        self,
+        use_description: bool = False,
+        name_to_id: dict[str, str] | None = None,
+    ) -> str:
+        """Generate an ``hl.monitor({ ... })`` block for Hyprland >= 0.55."""
+        lines: list[str] = ["hl.monitor({"]
+
+        if use_description and self.description:
+            output = f"desc:{self.description}"
+        else:
+            output = self.name
+        lines.append(_lua_field("output", output))
+
+        if not self.enabled:
+            lines.append(_lua_field("disabled", True))
+            return "\n".join(lines) + "\n})"
+
+        if self.resolution_mode == ResolutionMode.EXPLICIT:
+            refresh = f"{self.refresh_rate:g}"
+            mode = f"{self.width}x{self.height}@{refresh}"
+        else:
+            mode = self.resolution_mode.value
+        lines.append(_lua_field("mode", mode))
+
+        if self.position_mode == PositionMode.EXPLICIT:
+            position = f"{self.x}x{self.y}"
+        else:
+            position = self.position_mode.value
+        lines.append(_lua_field("position", position))
+
+        if self.scale_mode == ScaleMode.AUTO:
+            lines.append(_lua_field("scale", "auto"))
+        else:
+            lines.append(_lua_field("scale", self.scale))
+
+        if self.transform != Transform.NORMAL:
+            lines.append(_lua_field("transform", self.transform.value))
+
+        if self.mirror_of:
+            mirror_id = self.mirror_of
+            if name_to_id and self.mirror_of in name_to_id:
+                mirror_id = name_to_id[self.mirror_of]
+            lines.append(_lua_field("mirror", mirror_id))
+
+        if self.bitdepth != 8:
+            lines.append(_lua_field("bitdepth", self.bitdepth))
+
+        if self.vrr != VRR.OFF:
+            lines.append(_lua_field("vrr", self.vrr.value))
+
+        cm = self.color_management or ("hdr" if self.hdr else "")
+        if cm:
+            lines.append(_lua_field("cm", cm))
+
+        if self.sdr_brightness != 1.0:
+            lines.append(_lua_field("sdrbrightness", self.sdr_brightness))
+        if self.sdr_saturation != 1.0:
+            lines.append(_lua_field("sdrsaturation", self.sdr_saturation))
+
+        if any((self.reserved_top, self.reserved_bottom, self.reserved_left, self.reserved_right)):
+            lines.append(
+                "  reserved_area = { "
+                f"top = {self.reserved_top}, bottom = {self.reserved_bottom}, "
+                f"left = {self.reserved_left}, right = {self.reserved_right} "
+                "},"
+            )
+
+        sdr_eotf = {1: "srgb", 2: "gamma22"}.get(self.sdr_eotf)
+        if sdr_eotf:
+            lines.append(_lua_field("sdr_eotf", sdr_eotf))
+        if self.supports_hdr != 0:
+            lines.append(_lua_field("supports_hdr", self.supports_hdr))
+        if self.supports_wide_color != 0:
+            lines.append(_lua_field("supports_wide_color", self.supports_wide_color))
+        if self.sdr_min_luminance != 0.0:
+            lines.append(_lua_field("sdr_min_luminance", self.sdr_min_luminance))
+        if self.sdr_max_luminance != 0.0:
+            lines.append(_lua_field("sdr_max_luminance", self.sdr_max_luminance))
+        if self.min_luminance != 0.0:
+            lines.append(_lua_field("min_luminance", self.min_luminance))
+        if self.max_luminance != 0.0:
+            lines.append(_lua_field("max_luminance", self.max_luminance))
+        if self.max_avg_luminance != 0.0:
+            lines.append(_lua_field("max_avg_luminance", self.max_avg_luminance))
+
+        return "\n".join(lines) + "\n})"
+
     def to_dict(self) -> dict:
         """Serialize to a JSON-friendly dict."""
         d = asdict(self)
@@ -791,6 +905,38 @@ class WorkspaceRule:
             parts.append(f"on-created-empty:{self.on_created_empty}")
 
         return "workspace=" + ", ".join(parts)
+
+    def to_hyprland_lua_line(self, name_to_id: dict[str, str] | None = None) -> str:
+        """Generate an ``hl.workspace_rule({ ... })`` line for Hyprland >= 0.55."""
+        fields: list[str] = [_lua_field("workspace", self.workspace, indent=0).strip()]
+
+        if self.monitor:
+            monitor_id = (
+                name_to_id[self.monitor]
+                if name_to_id and self.monitor in name_to_id
+                else self.monitor
+            )
+            fields.append(_lua_field("monitor", monitor_id, indent=0).strip())
+        if self.default:
+            fields.append(_lua_field("default", True, indent=0).strip())
+        if self.persistent:
+            fields.append(_lua_field("persistent", True, indent=0).strip())
+        if self.rounding >= 0:
+            fields.append(_lua_field("no_rounding", self.rounding == 0, indent=0).strip())
+        if self.decorate >= 0:
+            fields.append(_lua_field("decorate", bool(self.decorate), indent=0).strip())
+        if self.gapsin >= 0:
+            fields.append(_lua_field("gaps_in", self.gapsin, indent=0).strip())
+        if self.gapsout >= 0:
+            fields.append(_lua_field("gaps_out", self.gapsout, indent=0).strip())
+        if self.border >= 0:
+            fields.append(_lua_field("no_border", self.border == 0, indent=0).strip())
+        if self.bordersize >= 0:
+            fields.append(_lua_field("border_size", self.bordersize, indent=0).strip())
+        if self.on_created_empty:
+            fields.append(_lua_field("on_created_empty", self.on_created_empty, indent=0).strip())
+
+        return "hl.workspace_rule({ " + " ".join(fields) + " })"
 
     def to_sway_line(self, name_to_id: dict[str, str] | None = None) -> str:
         """Generate a workspace assignment line for sway config.
@@ -1078,6 +1224,27 @@ class Profile:
                 lines.append(w.to_hyprland_line(name_to_id=name_to_id))
         lines.append("")
         return "\n".join(lines)
+
+    def generate_lua_config(self, use_description: bool = False) -> str:
+        """Generate the full monitors.lua content for Hyprland >= 0.55."""
+        name_to_id: dict[str, str] = {}
+        for m in self.monitors:
+            if use_description and m.description:
+                name_to_id[m.name] = f"desc:{m.description}"
+            else:
+                name_to_id[m.name] = m.name
+
+        blocks: list[str] = ["-- Generated by Monique - https://github.com/ToRvaLDz/monique"]
+        for m in self.monitors:
+            blocks.append(m.to_hyprland_lua_block(
+                use_description=use_description, name_to_id=name_to_id,
+            ))
+        if self.workspace_rules:
+            blocks.append("\n".join(
+                w.to_hyprland_lua_line(name_to_id=name_to_id)
+                for w in self.workspace_rules
+            ))
+        return "\n\n".join(blocks) + "\n"
 
     def generate_sway_config(self, use_description: bool = False) -> str:
         """Generate the full monitors.conf content for Sway."""

--- a/src/monique/niri.py
+++ b/src/monique/niri.py
@@ -184,8 +184,11 @@ class NiriIPC:
         # Cross-write Hyprland config if Hyprland is installed
         if is_hyprland_installed():
             hypr_conf = hyprland_config_dir() / "monitors.conf"
+            hypr_lua = hyprland_config_dir() / "monitors.lua"
             backup_file(hypr_conf)
+            backup_file(hypr_lua)
             write_text(hypr_conf, profile.generate_config(use_description=use_description))
+            write_text(hypr_lua, profile.generate_lua_config(use_description=use_description))
 
         # Cross-write Sway config if Sway is installed
         if is_sway_installed():

--- a/src/monique/sway.py
+++ b/src/monique/sway.py
@@ -120,8 +120,11 @@ class SwayIPC:
         # Also write Hyprland config if Hyprland is installed
         if is_hyprland_installed():
             hypr_conf = hyprland_config_dir() / "monitors.conf"
+            hypr_lua = hyprland_config_dir() / "monitors.lua"
             backup_file(hypr_conf)
+            backup_file(hypr_lua)
             write_text(hypr_conf, profile.generate_config(use_description=use_description))
+            write_text(hypr_lua, profile.generate_lua_config(use_description=use_description))
 
         # Also write Niri config if Niri is installed
         if is_niri_installed():

--- a/src/monique/utils.py
+++ b/src/monique/utils.py
@@ -46,7 +46,7 @@ def is_niri_installed() -> bool:
 
 
 def _config_dir_override() -> Path | None:
-    """Restituisce il percorso personalizzato per monitors.conf, se configurato.
+    """Restituisce il percorso personalizzato per i file monitor, se configurato.
 
     Priorità: --config-dir (runtime) > settings.json > default del compositor.
     """

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -165,6 +165,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._current_profile_name: str = ""
         self._base_profile_name: str = ""  # profile before user edits (for revert)
         self._confirm_timer_id: int = 0
+        self._confirm_created_paths: list[Path] = []
         self._inhibit_profile_switch: bool = False
         self._osd: MonitorOSD | None = None
         self._dirty: bool = False
@@ -370,7 +371,7 @@ class MainWindow(Adw.ApplicationWindow):
         # ── Output Directory group ──
         grp_out = Adw.PreferencesGroup(
             title="Config Output",
-            description="Where monitors.conf is written (leave empty for compositor default)",
+            description="Where generated monitor config files are written (leave empty for compositor default)",
         )
         page.add(grp_out)
 
@@ -1017,16 +1018,22 @@ class MainWindow(Adw.ApplicationWindow):
 
         # Determine config path based on compositor
         if isinstance(self._ipc, NiriIPC):
-            monitors_conf = niri_config_dir() / "monitors.kdl"
+            config_paths = [niri_config_dir() / "monitors.kdl"]
         else:
-            monitors_conf = hyprland_config_dir() / "monitors.conf"
+            config_paths = [
+                hyprland_config_dir() / "monitors.conf",
+                hyprland_config_dir() / "monitors.lua",
+            ]
 
         # Snapshot workspaces (for revert)
         self._ws_snapshot = self._ipc.get_workspaces()
         self._migrated_workspaces: list[tuple[str, str]] = []
 
+        created_paths = [path for path in config_paths if not path.exists()]
+
         # Backup
-        backup_file(monitors_conf)
+        for path in config_paths:
+            backup_file(path)
 
         try:
             update_sddm = self._app_settings.get("update_sddm", True)
@@ -1039,7 +1046,9 @@ class MainWindow(Adw.ApplicationWindow):
             self._set_status("Configuration applied")
         except Exception as e:
             self._toast(f"Apply failed: {e}")
-            restore_backup(monitors_conf)
+            for path in config_paths:
+                if not restore_backup(path) and path in created_paths and path.exists():
+                    path.unlink()
             return
 
         # Migrate orphaned workspaces if setting is on (Niri handles this natively)
@@ -1047,7 +1056,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._migrate_orphaned_workspaces(profile)
 
         # Show confirmation dialog with countdown
-        self._show_confirm_dialog(monitors_conf)
+        self._show_confirm_dialog(config_paths, created_paths)
 
     def _migrate_orphaned_workspaces(self, profile: Profile) -> None:
         """Move workspaces from disabled/removed monitors to the primary monitor."""
@@ -1069,7 +1078,7 @@ class MainWindow(Adw.ApplicationWindow):
                 except Exception:
                     pass
 
-    def _show_confirm_dialog(self, conf_path) -> None:
+    def _show_confirm_dialog(self, conf_paths, created_paths) -> None:
         self._confirm_remaining = CONFIRM_TIMEOUT
         dialog = Adw.AlertDialog()
         dialog.set_heading("Keep Settings?")
@@ -1082,7 +1091,8 @@ class MainWindow(Adw.ApplicationWindow):
         dialog.set_close_response("revert")
 
         self._confirm_dialog = dialog
-        self._confirm_conf_path = conf_path
+        self._confirm_conf_paths = list(conf_paths)
+        self._confirm_created_paths = list(created_paths)
 
         # Start countdown
         self._confirm_timer_id = GLib.timeout_add(1000, self._confirm_tick)
@@ -1106,9 +1116,11 @@ class MainWindow(Adw.ApplicationWindow):
 
         if response == "keep":
             # Remove backup
-            bak = self._confirm_conf_path.with_suffix(self._confirm_conf_path.suffix + ".bak")
-            if bak.exists():
-                bak.unlink()
+            for path in self._confirm_conf_paths:
+                bak = path.with_suffix(path.suffix + ".bak")
+                if bak.exists():
+                    bak.unlink()
+            self._confirm_created_paths = []
             self._migrated_workspaces = []
             self._base_profile_name = self._current_profile_name
             self._last_applied_time = time.time()
@@ -1131,7 +1143,16 @@ class MainWindow(Adw.ApplicationWindow):
                 pass
         self._migrated_workspaces = []
 
-        if restore_backup(self._confirm_conf_path):
+        restored = False
+        for path in self._confirm_conf_paths:
+            if restore_backup(path):
+                restored = True
+            elif path in self._confirm_created_paths and path.exists():
+                path.unlink()
+                restored = True
+        self._confirm_created_paths = []
+
+        if restored:
             try:
                 self._ipc.reload()
             except Exception as e:


### PR DESCRIPTION
This pull request adds support for generating and managing Hyprland 0.55+ Lua-based monitor configuration files (`monitors.lua`) alongside the legacy `monitors.conf` format. 

For backwards compatibility it writes to both a `.conf` and `.lua` file which the user can decide to source in its config depending on the version.