### PR TITLE
feat: add icc support for hyprland v0.55+

### DIFF
--- a/src/monique/hypr_config.py
+++ b/src/monique/hypr_config.py
@@ -45,6 +45,7 @@ def write_hyprland_configs(
     fmt: str | None = None,
     use_description: bool = False,
     use_v2: bool = False,
+    supports_icc: bool = False,
 ) -> list[Path]:
     """Back up and write the Hyprland monitor configs, returning the paths written."""
     fmt = _resolve_format(fmt)
@@ -55,7 +56,9 @@ def write_hyprland_configs(
         monitors_conf = conf_dir / "monitors.conf"
         backup_file(monitors_conf)
         write_text(monitors_conf, profile.generate_config(
-            use_description=use_description, use_v2=use_v2,
+            use_description=use_description,
+            use_v2=use_v2,
+            supports_icc=supports_icc,
         ))
         written.append(monitors_conf)
 

--- a/src/monique/hyprland.py
+++ b/src/monique/hyprland.py
@@ -268,7 +268,6 @@ class HyprlandIPC:
                 line = m.to_hyprland_line(
                     use_description=use_description,
                     name_to_id=name_to_id,
-                    supports_icc=self.supports_icc,
                 )
                 # strip "monitor=" prefix for keyword command
                 value = line.removeprefix("monitor=")

--- a/src/monique/hyprland.py
+++ b/src/monique/hyprland.py
@@ -33,6 +33,7 @@ class HyprlandIPC:
         self._runtime = hyprland_runtime_dir()
         self._version: tuple[int, int, int] | None = None
         self._supports_v2: bool | None = None
+        self._supports_icc: bool | None = None
 
     def get_version(self) -> tuple[int, int, int]:
         """Return the Hyprland version as (major, minor, patch).
@@ -63,6 +64,13 @@ class HyprlandIPC:
         if self._supports_v2 is None:
             self._supports_v2 = self.get_version() >= (0, 50, 0)
         return self._supports_v2
+
+    @property
+    def supports_icc(self) -> bool:
+        """True if the running Hyprland supports monitor ICC profiles (>= 0.55)."""
+        if self._supports_icc is None:
+            self._supports_icc = self.get_version() >= (0, 55, 0)
+        return self._supports_icc
 
     @property
     def command_socket(self) -> Path:
@@ -197,6 +205,7 @@ class HyprlandIPC:
         write_hyprland_configs(
             profile, fmt=hypr_config_format,
             use_description=use_description, use_v2=self.supports_v2,
+            supports_icc=self.supports_icc,
         )
 
         # Also write Sway config if Sway is installed
@@ -238,7 +247,9 @@ class HyprlandIPC:
         if self.supports_v2:
             for m in profile.monitors:
                 block = m.to_hyprland_v2_block(
-                    use_description=use_description, name_to_id=name_to_id,
+                    use_description=use_description,
+                    name_to_id=name_to_id,
+                    supports_icc=self.supports_icc,
                 )
                 # Strip "monitorv2 {" and "}" to get inner content,
                 # then send each line as a keyword command
@@ -255,7 +266,9 @@ class HyprlandIPC:
         else:
             for m in profile.monitors:
                 line = m.to_hyprland_line(
-                    use_description=use_description, name_to_id=name_to_id,
+                    use_description=use_description,
+                    name_to_id=name_to_id,
+                    supports_icc=self.supports_icc,
                 )
                 # strip "monitor=" prefix for keyword command
                 value = line.removeprefix("monitor=")

--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -161,6 +161,7 @@ class MonitorConfig:
     bitdepth: int = 8           # 8 or 10
     vrr: VRR = VRR.OFF
     color_management: str = ""  # "", "srgb", "dcip3", "dp3", "adobe", "wide", "edid", "hdr", "hdredid"
+    icc_profile: str = ""       # Absolute path, Hyprland newer monitorv2 / Lua configs
     sdr_brightness: float = 1.0
     sdr_saturation: float = 1.0
 
@@ -404,6 +405,7 @@ class MonitorConfig:
         self,
         use_description: bool = False,
         name_to_id: dict[str, str] | None = None,
+        supports_icc: bool = True,
     ) -> str:
         """Generate the `monitor=...` config line for hyprland.conf."""
         parts: list[str] = []
@@ -456,7 +458,9 @@ class MonitorConfig:
         if self.vrr != VRR.OFF:
             extras.append(f"vrr, {self.vrr.value}")
 
-        if self.color_management:
+        if supports_icc and self.icc_profile:
+            extras.append(f"icc, {self.icc_profile}")
+        elif self.color_management:
             extras.append(f"cm, {self.color_management}")
 
         if self.sdr_brightness != 1.0:
@@ -481,6 +485,7 @@ class MonitorConfig:
         self,
         use_description: bool = False,
         name_to_id: dict[str, str] | None = None,
+        supports_icc: bool = True,
     ) -> str:
         """Generate a ``monitorv2 { … }`` config block for Hyprland >= 0.50."""
         lines: list[str] = []
@@ -534,10 +539,13 @@ class MonitorConfig:
         if self.vrr != VRR.OFF:
             lines.append(f"  vrr = {self.vrr.value}")
 
-        # Color management (hdr bool falls back to cm = hdr if no explicit cm set)
-        cm = self.color_management or ("hdr" if self.hdr else "")
-        if cm:
-            lines.append(f"  cm = {cm}")
+        # ICC overrides CM presets on newer Hyprland versions.
+        if supports_icc and self.icc_profile:
+            lines.append(f"  icc = {self.icc_profile}")
+        else:
+            cm = self.color_management or ("hdr" if self.hdr else "")
+            if cm:
+                lines.append(f"  cm = {cm}")
 
         # SDR brightness / saturation
         if self.sdr_brightness != 1.0:
@@ -577,6 +585,7 @@ class MonitorConfig:
         self,
         use_description: bool = False,
         name_to_id: dict[str, str] | None = None,
+        supports_icc: bool = True,
     ) -> str:
         """Generate an ``hl.monitor({ ... })`` block for Hyprland >= 0.55."""
         lines: list[str] = ["hl.monitor({"]
@@ -624,9 +633,12 @@ class MonitorConfig:
         if self.vrr != VRR.OFF:
             lines.append(_lua_field("vrr", self.vrr.value))
 
-        cm = self.color_management or ("hdr" if self.hdr else "")
-        if cm:
-            lines.append(_lua_field("cm", cm))
+        if supports_icc and self.icc_profile:
+            lines.append(_lua_field("icc", self.icc_profile))
+        else:
+            cm = self.color_management or ("hdr" if self.hdr else "")
+            if cm:
+                lines.append(_lua_field("cm", cm))
 
         if self.sdr_brightness != 1.0:
             lines.append(_lua_field("sdrbrightness", self.sdr_brightness))
@@ -732,6 +744,7 @@ class MonitorConfig:
             enabled=not disabled,
             vrr=vrr_val,
             color_management=data.get("colorManagementPreset", ""),
+            icc_profile=data.get("iccProfile", data.get("icc", "")),
             sdr_brightness=data.get("sdrBrightness", 1.0),
             sdr_saturation=data.get("sdrSaturation", 1.0),
             sdr_min_luminance=data.get("sdrMinLuminance", 0.0),
@@ -1270,7 +1283,12 @@ class Profile:
             last_applied_time=d.get("last_applied_time", 0.0),
         )
 
-    def generate_config(self, use_description: bool = False, use_v2: bool = False) -> str:
+    def generate_config(
+        self,
+        use_description: bool = False,
+        use_v2: bool = False,
+        supports_icc: bool = True,
+    ) -> str:
         """Generate the full monitors.conf content for Hyprland."""
         # Build name→identifier mapping for workspace rules and mirror references
         name_to_id: dict[str, str] = {}
@@ -1286,13 +1304,17 @@ class Profile:
         if use_v2:
             for m in self.monitors:
                 lines.append(m.to_hyprland_v2_block(
-                    use_description=use_description, name_to_id=name_to_id,
+                    use_description=use_description,
+                    name_to_id=name_to_id,
+                    supports_icc=supports_icc,
                 ))
                 lines.append("")
         else:
             for m in self.monitors:
                 lines.append(m.to_hyprland_line(
-                    use_description=use_description, name_to_id=name_to_id,
+                    use_description=use_description,
+                    name_to_id=name_to_id,
+                    supports_icc=supports_icc,
                 ))
         if self.workspace_rules:
             lines.append("")
@@ -1301,7 +1323,7 @@ class Profile:
         lines.append("")
         return "\n".join(lines)
 
-    def generate_lua_config(self, use_description: bool = False) -> str:
+    def generate_lua_config(self, use_description: bool = False, supports_icc: bool = True) -> str:
         """Generate the full monitors.lua content for Hyprland >= 0.55."""
         name_to_id: dict[str, str] = {}
         for m in self.monitors:
@@ -1313,7 +1335,9 @@ class Profile:
         blocks: list[str] = ["-- Generated by Monique - https://github.com/ToRvaLDz/monique"]
         for m in self.monitors:
             blocks.append(m.to_hyprland_lua_block(
-                use_description=use_description, name_to_id=name_to_id,
+                use_description=use_description,
+                name_to_id=name_to_id,
+                supports_icc=supports_icc,
             ))
         if self.workspace_rules:
             blocks.append("\n".join(

--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -405,7 +405,6 @@ class MonitorConfig:
         self,
         use_description: bool = False,
         name_to_id: dict[str, str] | None = None,
-        supports_icc: bool = True,
     ) -> str:
         """Generate the `monitor=...` config line for hyprland.conf."""
         parts: list[str] = []
@@ -458,9 +457,7 @@ class MonitorConfig:
         if self.vrr != VRR.OFF:
             extras.append(f"vrr, {self.vrr.value}")
 
-        if supports_icc and self.icc_profile:
-            extras.append(f"icc, {self.icc_profile}")
-        elif self.color_management:
+        if self.color_management:
             extras.append(f"cm, {self.color_management}")
 
         if self.sdr_brightness != 1.0:
@@ -485,7 +482,7 @@ class MonitorConfig:
         self,
         use_description: bool = False,
         name_to_id: dict[str, str] | None = None,
-        supports_icc: bool = True,
+        supports_icc: bool = False,
     ) -> str:
         """Generate a ``monitorv2 { … }`` config block for Hyprland >= 0.50."""
         lines: list[str] = []
@@ -585,7 +582,6 @@ class MonitorConfig:
         self,
         use_description: bool = False,
         name_to_id: dict[str, str] | None = None,
-        supports_icc: bool = True,
     ) -> str:
         """Generate an ``hl.monitor({ ... })`` block for Hyprland >= 0.55."""
         lines: list[str] = ["hl.monitor({"]
@@ -633,7 +629,7 @@ class MonitorConfig:
         if self.vrr != VRR.OFF:
             lines.append(_lua_field("vrr", self.vrr.value))
 
-        if supports_icc and self.icc_profile:
+        if self.icc_profile:
             lines.append(_lua_field("icc", self.icc_profile))
         else:
             cm = self.color_management or ("hdr" if self.hdr else "")
@@ -1287,7 +1283,7 @@ class Profile:
         self,
         use_description: bool = False,
         use_v2: bool = False,
-        supports_icc: bool = True,
+        supports_icc: bool = False,
     ) -> str:
         """Generate the full monitors.conf content for Hyprland."""
         # Build name→identifier mapping for workspace rules and mirror references
@@ -1314,7 +1310,6 @@ class Profile:
                 lines.append(m.to_hyprland_line(
                     use_description=use_description,
                     name_to_id=name_to_id,
-                    supports_icc=supports_icc,
                 ))
         if self.workspace_rules:
             lines.append("")
@@ -1323,7 +1318,7 @@ class Profile:
         lines.append("")
         return "\n".join(lines)
 
-    def generate_lua_config(self, use_description: bool = False, supports_icc: bool = True) -> str:
+    def generate_lua_config(self, use_description: bool = False) -> str:
         """Generate the full monitors.lua content for Hyprland >= 0.55."""
         name_to_id: dict[str, str] = {}
         for m in self.monitors:
@@ -1337,7 +1332,6 @@ class Profile:
             blocks.append(m.to_hyprland_lua_block(
                 use_description=use_description,
                 name_to_id=name_to_id,
-                supports_icc=supports_icc,
             ))
         if self.workspace_rules:
             blocks.append("\n".join(

--- a/src/monique/properties_panel.py
+++ b/src/monique/properties_panel.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
-from gi.repository import Gtk, Adw, GLib, GObject
+from gi.repository import Gtk, Adw, GLib, GObject, Gio
 
 from .models import (
     MonitorConfig, ResolutionMode, PositionMode, ScaleMode,
@@ -62,6 +64,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._monitor: MonitorConfig | None = None
         self._building = False
         self._backend: str = "hyprland"  # "hyprland", "sway", or "niri"
+        self._hyprland_icc: bool = False
 
         self._build_ui()
 
@@ -189,6 +192,17 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._combo_cm.connect("notify::selected", self._on_changed)
         self._grp_adv.add(self._combo_cm)
 
+        self._entry_icc = Adw.EntryRow(title="ICC Profile (Hyprland v0.55+)")
+        self._entry_icc.set_input_hints(Gtk.InputHints.NO_SPELLCHECK)
+        self._entry_icc.set_input_purpose(Gtk.InputPurpose.URL)
+        self._entry_icc.connect("changed", self._on_changed)
+        btn_icc = Gtk.Button(icon_name="document-open-symbolic")
+        btn_icc.set_valign(Gtk.Align.CENTER)
+        btn_icc.set_tooltip_text("Choose ICC profile")
+        btn_icc.connect("clicked", self._on_pick_icc_clicked)
+        self._entry_icc.add_suffix(btn_icc)
+        self._grp_adv.add(self._entry_icc)
+
         self._spin_sdr_bright = Adw.SpinRow.new_with_range(0.0, 5.0, 0.05)
         self._spin_sdr_bright.set_title("SDR Brightness")
         self._spin_sdr_bright.set_digits(2)
@@ -295,18 +309,25 @@ class PropertiesPanel(Adw.PreferencesPage):
         # Default to insensitive
         self._grp_hdr.set_sensitive(False)
 
-    def set_compositor(self, backend: str, hyprland_v2: bool = False) -> None:
+    def set_compositor(
+        self,
+        backend: str,
+        hyprland_v2: bool = False,
+        hyprland_icc: bool = False,
+    ) -> None:
         """Disable controls not supported by the active compositor.
 
         backend should be "hyprland", "sway", or "niri".
         """
         self._backend = backend
+        self._hyprland_icc = hyprland_icc
         is_hyprland = backend == "hyprland"
 
         # Hyprland-only Advanced controls
         self._combo_mirror.set_sensitive(is_hyprland)
         self._combo_bitdepth.set_sensitive(is_hyprland)
         self._combo_cm.set_sensitive(is_hyprland)
+        self._entry_icc.set_sensitive(is_hyprland and hyprland_icc)
         self._spin_sdr_bright.set_sensitive(is_hyprland)
         self._spin_sdr_sat.set_sensitive(is_hyprland)
 
@@ -347,6 +368,7 @@ class PropertiesPanel(Adw.PreferencesPage):
 
         # HDR / EDID Override: only for Hyprland >= 0.50
         self._grp_hdr.set_sensitive(is_hyprland and hyprland_v2)
+        self._update_icc_validation()
 
     def set_enabled_locked(self, locked: bool) -> None:
         """Lock the Enabled switch (e.g. for clamshell-managed monitors)."""
@@ -446,6 +468,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         cm_val = monitor.color_management or "None"
         idx = cm_options.index(cm_val) if cm_val in cm_options else 0
         self._combo_cm.set_selected(idx)
+        self._entry_icc.set_text(monitor.icc_profile)
 
         self._spin_sdr_bright.set_value(monitor.sdr_brightness)
         self._spin_sdr_sat.set_value(monitor.sdr_saturation)
@@ -468,6 +491,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_max_avg_lum.set_value(monitor.max_avg_luminance)
 
         self._building = False
+        self._update_icc_validation()
 
     def _apply_to_monitor(self) -> None:
         """Write current UI values back to the MonitorConfig."""
@@ -515,6 +539,8 @@ class PropertiesPanel(Adw.PreferencesPage):
 
         cm_options = ["", "auto", "srgb", "dcip3", "dp3", "adobe", "wide", "edid", "hdr", "hdredid"]
         m.color_management = cm_options[self._combo_cm.get_selected()]
+        icc_profile = self._entry_icc.get_text().strip()
+        m.icc_profile = icc_profile if not icc_profile or Path(icc_profile).is_absolute() else ""
 
         m.sdr_brightness = round(self._spin_sdr_bright.get_value(), 2)
         m.sdr_saturation = round(self._spin_sdr_sat.get_value(), 2)
@@ -552,8 +578,24 @@ class PropertiesPanel(Adw.PreferencesPage):
     def _on_changed(self, *args) -> None:
         if self._building or self._monitor is None:
             return
+        self._update_icc_validation()
         self._apply_to_monitor()
         self.emit("property-changed")
+
+    def _update_icc_validation(self) -> None:
+        icc_profile = self._entry_icc.get_text().strip()
+        is_valid = not icc_profile or Path(icc_profile).is_absolute()
+
+        if is_valid:
+            self._entry_icc.remove_css_class("error")
+            if self._backend == "hyprland" and not self._hyprland_icc:
+                self._entry_icc.set_tooltip_text("Requires Hyprland 0.55 or newer")
+            else:
+                self._entry_icc.set_tooltip_text(None)
+            return
+
+        self._entry_icc.add_css_class("error")
+        self._entry_icc.set_tooltip_text("ICC profile path must be absolute")
 
     def _on_res_mode_changed(self, *args) -> None:
         if self._building:
@@ -596,6 +638,47 @@ class PropertiesPanel(Adw.PreferencesPage):
         mode = self._combo_enum_value(self._combo_scale_mode, ScaleMode, ScaleMode.EXPLICIT)
         self._spin_scale.set_visible(mode == ScaleMode.EXPLICIT)
         self._on_changed()
+
+    def _on_pick_icc_clicked(self, *args) -> None:
+        chooser = Gtk.FileChooserNative.new(
+            "Choose ICC Profile",
+            self.get_root(),
+            Gtk.FileChooserAction.OPEN,
+            "Open",
+            "Cancel",
+        )
+
+        filter_icc = Gtk.FileFilter()
+        filter_icc.set_name("ICC profiles")
+        filter_icc.add_pattern("*.icc")
+        filter_icc.add_pattern("*.icm")
+        filter_icc.add_pattern("*.ICC")
+        filter_icc.add_pattern("*.ICM")
+        chooser.add_filter(filter_icc)
+
+        filter_all = Gtk.FileFilter()
+        filter_all.set_name("All files")
+        filter_all.add_pattern("*")
+        chooser.add_filter(filter_all)
+        chooser.set_filter(filter_icc)
+
+        current_path = self._entry_icc.get_text().strip()
+        if current_path:
+            current_file = Gio.File.new_for_path(current_path)
+            if current_file.query_exists(None):
+                chooser.set_file(current_file)
+
+        chooser.connect("response", self._on_icc_file_response)
+        chooser.show()
+
+    def _on_icc_file_response(self, chooser: Gtk.FileChooserNative, response: int) -> None:
+        if response == Gtk.ResponseType.ACCEPT:
+            file = chooser.get_file()
+            if file is not None:
+                path = file.get_path()
+                if path:
+                    self._entry_icc.set_text(path)
+        chooser.destroy()
 
     @staticmethod
     def _find_combo_index(combo: Adw.ComboRow, value: str) -> int:

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -272,6 +272,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._props.set_compositor(
                 "hyprland",
                 hyprland_v2=self._ipc.supports_v2,
+                hyprland_icc=self._ipc.supports_icc,
             )
         self._props.connect("property-changed", self._on_property_changed)
         scroll.set_child(self._props)


### PR DESCRIPTION
This pull request adds support for configuring monitor ICC profiles in Hyprland (version 0.55 and newer). It introduces a new `icc_profile` field to monitor configurations, which allows the user to either write an absolute path to the profile or pick it with the gtk file picker. There is validation to ensure that ICC profiles are only enabled for Hyprland versions that support them.