### PR TITLE
refactor: overhaul flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-FGQ8TfSm9WviNE/fQAWsKs+y4GkX8fU4EScewpw54Y8=",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1027867.d407951447dc/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,9 @@
 
       forEachSystem =
         perSystem:
-        lib.genAttrs lib.platforms.linux (system: perSystem nixpkgs.legacyPackages.${system} system);
+        lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (
+          system: perSystem nixpkgs.legacyPackages.${system} system
+        );
     in
     {
       overlays.default = final: _prev: {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland and Sway";
+  description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland, Sway and Niri";
 
   inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,121 +1,41 @@
 {
   description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland and Sway";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs =
+    { self, nixpkgs }:
     let
-      # Derivazione riutilizzabile (riceve pkgs dal chiamante)
-      mkMonique = pkgs: pkgs.python3Packages.buildPythonPackage {
-        pname = "monique";
-        version = "0.5.0";
-        format = "pyproject";
+      inherit (nixpkgs) lib;
 
-        src = self;
-
-        nativeBuildInputs = with pkgs; [
-          python3Packages.setuptools
-          wrapGAppsHook4
-          gobject-introspection
-        ];
-
-        buildInputs = with pkgs; [
-          gtk4
-          libadwaita
-        ];
-
-        propagatedBuildInputs = with pkgs.python3Packages; [
-          pygobject3
-          pyudev
-        ];
-
-        postInstall = ''
-          install -Dm644 data/com.github.monique.desktop \
-            $out/share/applications/com.github.monique.desktop
-          install -Dm644 data/com.github.monique.svg \
-            $out/share/icons/hicolor/scalable/apps/com.github.monique.svg
-          install -Dm644 data/moniqued.service \
-            $out/lib/systemd/user/moniqued.service
-        '';
-
-        # I test non esistono ancora
-        doCheck = false;
-
-        meta = with pkgs.lib; {
-          description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland and Sway";
-          homepage = "https://github.com/ToRvaLDz/monique";
-          license = licenses.gpl3Plus;
-          platforms = platforms.linux;
-          mainProgram = "monique";
-        };
-      };
+      forEachSystem =
+        perSystem:
+        lib.genAttrs lib.platforms.linux (system: perSystem nixpkgs.legacyPackages.${system} system);
     in
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
-        packages.default = mkMonique pkgs;
-
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            python3
-            python3Packages.pygobject3
-            python3Packages.pyudev
-            python3Packages.setuptools
-            gtk4
-            libadwaita
-            gobject-introspection
-          ];
-        };
-      }
-    ) // {
-      # Overlay: nix.overlays = [ monique.overlays.default ]
+    {
       overlays.default = final: _prev: {
-        monique = mkMonique final;
+        monique = final.callPackage ./nix/package.nix { };
       };
 
-      # NixOS module
-      nixosModules.default = { config, lib, pkgs, ... }:
-        let
-          cfg = config.programs.monique;
-          package = mkMonique pkgs;
-        in
+      packages = forEachSystem (
+        pkgs: _system: {
+          default = pkgs.callPackage ./nix/package.nix { };
+        }
+      );
+
+      devShells = forEachSystem (
+        pkgs: system: {
+          default = pkgs.callPackage ./nix/devshell.nix {
+            monique = self.packages.${system}.default;
+          };
+        }
+      );
+
+      nixosModules.default =
+        { pkgs, lib, ... }:
         {
-          options.programs.monique = {
-            enable = lib.mkEnableOption "Monique monitor configurator";
-
-            enablePolkit = lib.mkOption {
-              type = lib.types.bool;
-              default = true;
-              description = ''
-                Installa la regola polkit per consentire scritture su
-                /usr/share/sddm/scripts/Xsetup e /etc/greetd/monique-monitors.conf
-                senza richiedere la password.
-              '';
-            };
-          };
-
-          config = lib.mkIf cfg.enable {
-            environment.systemPackages = [ package ];
-
-            # Regola polkit: usa il percorso Nix di coreutils per `tee`
-            security.polkit.extraConfig = lib.mkIf cfg.enablePolkit ''
-              polkit.addRule(function(action, subject) {
-                if (action.id === "org.freedesktop.policykit.exec" &&
-                    action.lookup("program") === "${pkgs.coreutils}/bin/tee" &&
-                    (action.lookup("command_line").indexOf("/usr/share/sddm/scripts/Xsetup") !== -1 ||
-                     action.lookup("command_line").indexOf("/etc/greetd/monique-monitors.conf") !== -1) &&
-                    subject.active === true &&
-                    subject.local  === true) {
-                    return polkit.Result.YES;
-                }
-              });
-            '';
-          };
+          imports = [ ./nix/nixos-module.nix ];
+          programs.monique.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
         };
     };
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,11 @@
+{
+  pkgs,
+  monique,
+}:
+pkgs.mkShell {
+  inputsFrom = [ monique ];
+
+  packages = with pkgs; [
+    python3
+  ];
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -12,8 +12,7 @@ in
     enable = lib.mkEnableOption "Monique monitor configurator";
 
     package = lib.mkOption {
-      type = lib.types.nullOr lib.types.package;
-      default = null;
+      type = lib.types.package;
       description = "The Monique package to install.";
     };
 
@@ -29,7 +28,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = lib.optional (cfg.package != null) cfg.package;
+    environment.systemPackages = [ cfg.package ];
 
     security.polkit.enable = lib.mkDefault cfg.enablePolkit;
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -30,6 +30,8 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
+    systemd.packages = [ cfg.package ];
+
     security.polkit.enable = lib.mkDefault cfg.enablePolkit;
 
     environment.etc."polkit-1/rules.d/60-com.github.monique.rules" = lib.mkIf cfg.enablePolkit {

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.monique;
+in
+{
+  options.programs.monique = {
+    enable = lib.mkEnableOption "Monique monitor configurator";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "The Monique package to install.";
+    };
+
+    enablePolkit = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Install the polkit rule to allow writing to
+        /usr/share/sddm/scripts/Xsetup and /etc/greetd/monique-monitors.conf
+        without requiring a password.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = lib.optional (cfg.package != null) cfg.package;
+
+    environment.etc."polkit-1/rules.d/60-com.github.monique.rules" = lib.mkIf cfg.enablePolkit {
+      text = ''
+        polkit.addRule(function(action, subject) {
+          if (action.id === "org.freedesktop.policykit.exec" &&
+              action.lookup("program") === "${pkgs.coreutils}/bin/tee" &&
+              (action.lookup("command_line").indexOf("/usr/share/sddm/scripts/Xsetup") !== -1 ||
+               action.lookup("command_line").indexOf("/etc/greetd/monique-monitors.conf") !== -1) &&
+              subject.active === true &&
+              subject.local  === true) {
+            return polkit.Result.YES;
+          }
+        });
+      '';
+    };
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -31,6 +31,8 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = lib.optional (cfg.package != null) cfg.package;
 
+    security.polkit.enable = lib.mkDefault cfg.enablePolkit;
+
     environment.etc."polkit-1/rules.d/60-com.github.monique.rules" = lib.mkIf cfg.enablePolkit {
       text = ''
         polkit.addRule(function(action, subject) {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonPackage {
   doCheck = false;
 
   meta = {
-    description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland and Sway";
+    description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland, Sway and Niri";
     homepage = "https://github.com/ToRvaLDz/monique";
     license = lib.licenses.gpl3Plus;
     platforms = [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  python3Packages,
+  gtk4,
+  libadwaita,
+  gobject-introspection,
+  wrapGAppsHook4,
+}:
+let
+  version = (fromTOML (builtins.readFile ../pyproject.toml)).project.version;
+in
+python3Packages.buildPythonPackage {
+  pname = "monique";
+  inherit version;
+  format = "pyproject";
+
+  src = lib.cleanSource ./..;
+
+  nativeBuildInputs = [
+    python3Packages.setuptools
+    wrapGAppsHook4
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    pyudev
+  ];
+
+  postInstall = ''
+    install -Dm644 data/com.github.monique.desktop \
+      $out/share/applications/com.github.monique.desktop
+    install -Dm644 data/com.github.monique.svg \
+      $out/share/icons/hicolor/scalable/apps/com.github.monique.svg
+    install -Dm644 data/moniqued.service \
+      $out/lib/systemd/user/moniqued.service
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland and Sway";
+    homepage = "https://github.com/ToRvaLDz/monique";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "monique";
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -47,7 +47,10 @@ python3Packages.buildPythonPackage {
     description = "MONitor Integrated QUick Editor — graphical monitor configurator for Hyprland and Sway";
     homepage = "https://github.com/ToRvaLDz/monique";
     license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "monique";
   };
 }


### PR DESCRIPTION
This PR overhauls the flake to be more maintainable and follow current best practices.

- Split package, NixOS module, and devshell into their own files under nix/
- Dropped flake-utils dependency in favor of a small helper
- Version is now extracted from `pyproject.toml` at build time instead of being hardcoded
- Added a package option to the NixOS module so users can override which package gets installed
- Moved the polkit rule to a dedicated file via `environment.etc` for controllable ordering and to avoid interference with `10-nixos.rules`
- Dev shell now uses inputsFrom to pull build inputs from the package, avoiding duplication
- Translated all option descriptions to English
- Switched nixpkgs input to the channel tarball URL as it is faster, has no rate limits and is more reliable

Tested nix run, nix develop, as well as using the NixOS module in my own config.