### PR TITLE
feat: add hints to HDR-dependent settings and remove HDR toggle

### DIFF
--- a/src/monique/models.py
+++ b/src/monique/models.py
@@ -185,7 +185,6 @@ class MonitorConfig:
     sdr_saturation: float = 1.0
 
     # HDR / EDID Override (Hyprland monitorv2 only)
-    hdr: bool = False
     sdr_eotf: int = 0              # 0=global, 1=sRGB, 2=Gamma 2.2
     supports_hdr: int = 0          # 0=auto, 1=force on
     supports_wide_color: int = 0   # 0=auto, 1=force on
@@ -559,7 +558,7 @@ class MonitorConfig:
         if supports_icc and self.icc_profile:
             lines.append(f"  icc = {self.icc_profile}")
         else:
-            cm = self.color_management or ("hdr" if self.hdr else "")
+            cm = self.color_management
             if cm:
                 lines.append(f"  cm = {cm}")
 
@@ -653,7 +652,7 @@ class MonitorConfig:
         if supports_icc and self.icc_profile:
             lines.append(_lua_field("icc", self.icc_profile))
         else:
-            cm = self.color_management or ("hdr" if self.hdr else "")
+            cm = self.color_management
             if cm:
                 lines.append(_lua_field("cm", cm))
 
@@ -1295,9 +1294,19 @@ class Profile:
 
     @classmethod
     def from_dict(cls, d: dict) -> Profile:
+        # legacy migration for "hdr" field
+        monitors = []
+        for m in d.get("monitors", []):
+            m = dict(m)  # defensive copy
+            if m.pop("hdr", False) and not m.get("color_management"):
+                # legacy profiles with "hdr": true and cm = ""
+                # which is equivalent to "cm=hdr" preset
+                m["color_management"] = "hdr"
+            monitors.append(m)
+
         return cls(
             name=d.get("name", ""),
-            monitors=[MonitorConfig.from_dict(m) for m in d.get("monitors", [])],
+            monitors=[MonitorConfig.from_dict(m) for m in monitors],
             workspace_rules=[WorkspaceRule.from_dict(w) for w in d.get("workspace_rules", [])],
             last_applied_time=d.get("last_applied_time", 0.0),
         )

--- a/src/monique/properties_panel.py
+++ b/src/monique/properties_panel.py
@@ -65,6 +65,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._building = False
         self._backend: str = "hyprland"  # "hyprland", "sway", or "niri"
         self._hyprland_icc: bool = False
+        self._hdr_dependent_rows: list[Gtk.Widget] = []
 
         self._build_ui()
 
@@ -215,6 +216,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_sdr_bright.set_title("SDR Brightness")
         self._spin_sdr_bright.set_digits(2)
         self._spin_sdr_bright.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_sdr_bright)
         self._grp_adv.add(self._spin_sdr_bright)
         _fix_spin_icons(self._spin_sdr_bright)
 
@@ -222,6 +224,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_sdr_sat.set_title("SDR Saturation")
         self._spin_sdr_sat.set_digits(2)
         self._spin_sdr_sat.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_sdr_sat)
         self._grp_adv.add(self._spin_sdr_sat)
         _fix_spin_icons(self._spin_sdr_sat)
 
@@ -267,6 +270,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._combo_sdr_eotf = Adw.ComboRow(title="SDR EOTF")
         self._combo_sdr_eotf.set_model(Gtk.StringList.new(["Global", "sRGB", "Gamma 2.2"]))
         self._combo_sdr_eotf.connect("notify::selected", self._on_changed)
+        self._hdr_dependent_rows.append(self._combo_sdr_eotf)
         self._grp_hdr.add(self._combo_sdr_eotf)
 
         self._combo_supports_hdr = Adw.ComboRow(title="Supports HDR")
@@ -283,6 +287,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_sdr_min_lum.set_title("SDR Min Luminance")
         self._spin_sdr_min_lum.set_digits(3)
         self._spin_sdr_min_lum.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_sdr_min_lum)
         self._grp_hdr.add(self._spin_sdr_min_lum)
         _fix_spin_icons(self._spin_sdr_min_lum)
 
@@ -290,6 +295,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_sdr_max_lum.set_title("SDR Max Luminance")
         self._spin_sdr_max_lum.set_digits(1)
         self._spin_sdr_max_lum.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_sdr_max_lum)
         self._grp_hdr.add(self._spin_sdr_max_lum)
         _fix_spin_icons(self._spin_sdr_max_lum)
 
@@ -297,6 +303,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_min_lum.set_title("Min Luminance")
         self._spin_min_lum.set_digits(1)
         self._spin_min_lum.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_min_lum)
         self._grp_hdr.add(self._spin_min_lum)
         _fix_spin_icons(self._spin_min_lum)
 
@@ -304,6 +311,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_max_lum.set_title("Max Luminance")
         self._spin_max_lum.set_digits(1)
         self._spin_max_lum.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_max_lum)
         self._grp_hdr.add(self._spin_max_lum)
         _fix_spin_icons(self._spin_max_lum)
 
@@ -311,11 +319,25 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_max_avg_lum.set_title("Max Avg Luminance")
         self._spin_max_avg_lum.set_digits(1)
         self._spin_max_avg_lum.connect("notify::value", self._on_changed)
+        self._hdr_dependent_rows.append(self._spin_max_avg_lum)
         self._grp_hdr.add(self._spin_max_avg_lum)
         _fix_spin_icons(self._spin_max_avg_lum)
 
         # Default to insensitive
         self._grp_hdr.set_sensitive(False)
+
+    def _hdr_dependent_settings_hints(self) -> None:
+        """Set subtitle/tooltip on HDR-dependent rows when CM won't apply them."""
+        cm_val = self._combo_cm.get_model().get_string(self._combo_cm.get_selected())
+        inactive = cm_val not in ("hdr", "hdredid")
+        tip = (
+            "Only applied when Color Management is set to hdr or hdredid, "
+            "or from auto hdr settings"
+            if inactive else None
+        )
+        for row in self._hdr_dependent_rows:
+            row.set_subtitle("inactive" if inactive else "")
+            row.set_tooltip_text(tip)
 
     def set_compositor(
         self,
@@ -503,6 +525,7 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_max_avg_lum.set_value(monitor.max_avg_luminance)
 
         self._building = False
+        self._hdr_dependent_settings_hints()
         self._sync_icc_ui()
 
     def _apply_to_monitor(self) -> None:
@@ -593,6 +616,7 @@ class PropertiesPanel(Adw.PreferencesPage):
             return
         self._sync_icc_ui()
         self._apply_to_monitor()
+        self._hdr_dependent_settings_hints()
         self.emit("property-changed")
 
     def _sync_icc_ui(self) -> None:

--- a/src/monique/properties_panel.py
+++ b/src/monique/properties_panel.py
@@ -263,10 +263,6 @@ class PropertiesPanel(Adw.PreferencesPage):
         )
         self.add(self._grp_hdr)
 
-        self._sw_hdr = Adw.SwitchRow(title="HDR")
-        self._sw_hdr.connect("notify::active", self._on_changed)
-        self._grp_hdr.add(self._sw_hdr)
-
         self._combo_sdr_eotf = Adw.ComboRow(title="SDR EOTF")
         self._combo_sdr_eotf.set_model(Gtk.StringList.new(["Global", "sRGB", "Gamma 2.2"]))
         self._combo_sdr_eotf.connect("notify::selected", self._on_changed)
@@ -514,7 +510,6 @@ class PropertiesPanel(Adw.PreferencesPage):
         self._spin_res_right.set_value(monitor.reserved_right)
 
         # HDR / EDID Override
-        self._sw_hdr.set_active(monitor.hdr)
         self._combo_sdr_eotf.set_selected(monitor.sdr_eotf)
         self._combo_supports_hdr.set_selected(monitor.supports_hdr)
         self._combo_supports_wide.set_selected(monitor.supports_wide_color)
@@ -588,7 +583,6 @@ class PropertiesPanel(Adw.PreferencesPage):
         m.reserved_right = int(self._spin_res_right.get_value())
 
         # HDR / EDID Override
-        m.hdr = self._sw_hdr.get_active()
         m.sdr_eotf = self._combo_sdr_eotf.get_selected()
         m.supports_hdr = self._combo_supports_hdr.get_selected()
         m.supports_wide_color = self._combo_supports_wide.get_selected()

--- a/tests/test_hdr_migration.py
+++ b/tests/test_hdr_migration.py
@@ -1,0 +1,87 @@
+"""Legacy hdr field migration to color_management preset when read from persistence."""
+
+from monique.models import Profile
+
+def _make_monitor(name: str = "DP-1", hdr: bool | None = None, cm: str = "") -> dict:
+    m = {"name": name, "width": 1920, "height": 1080}
+    if hdr is not None:
+        m["hdr"] = hdr
+    if cm:
+        m["color_management"] = cm
+    return m
+
+
+def _make_profile(name: str = "DP-1", hdr=None, cm="") -> Profile:
+    monitors = [_make_monitor(name, hdr, cm)]
+    return Profile.from_dict({"name": "test", "monitors": monitors})
+
+
+def test_migrates_hdr_true_without_cm():
+    p = _make_profile(hdr=True, cm = "")
+    assert p.monitors[0].color_management == "hdr"
+
+
+def test_leaves_hdr_true_with_explicit_cm_untouched():
+    p = _make_profile(hdr=True, cm = "srgb")
+    assert p.monitors[0].color_management == "srgb"
+
+    p = _make_profile(hdr=True, cm = "hdr")
+    assert p.monitors[0].color_management == "hdr"
+
+    p = _make_profile(hdr=True, cm = "auto")
+    assert p.monitors[0].color_management == "auto"
+
+
+def test_leaves_no_hdr_key_unchanged():
+    p = _make_profile(cm = "")
+    assert p.monitors[0].color_management == ""
+
+    p = _make_profile(cm = "srgb")
+    assert p.monitors[0].color_management == "srgb"
+
+    p = _make_profile(cm = "hdr")
+    assert p.monitors[0].color_management == "hdr"
+
+
+def test_leaves_hdr_false_unchanged():
+    p = _make_profile(hdr = False, cm = "")
+    assert p.monitors[0].color_management == ""
+
+    p = _make_profile(hdr = False, cm = "srgb")
+    assert p.monitors[0].color_management == "srgb"
+
+    p = _make_profile(hdr = False, cm = "hdr")
+    assert p.monitors[0].color_management == "hdr"
+
+
+def test_leaves_explicit_cm_without_hdr_unchanged():
+    p = _make_profile(cm = "dcip3")
+    assert p.monitors[0].color_management == "dcip3"
+
+
+def test_hdr_key_not_in_loaded_monitor_dict():
+    p = _make_profile(hdr = True)
+    assert "hdr" not in p.monitors[0].__dataclass_fields__
+
+
+def test_round_trip_preserves_migrated_value():
+    p = _make_profile(hdr = True, cm = "")
+    restored = Profile.from_dict(p.to_dict())
+    assert restored.monitors[0].color_management == "hdr"
+    assert "hdr" not in restored.to_dict()["monitors"][0]
+
+
+def test_multiple_monitors_migrate_independently():
+    raw = {
+        "name": "multi",
+        "monitors": [
+            _make_monitor(hdr=True),            # → cm = "hdr"
+            _make_monitor(hdr=False),           # → cm = ""
+            _make_monitor(cm="srgb"),           # → cm = "srgb"
+            _make_monitor(hdr=True, cm="hdr"),  # → cm = "hdr" (already set)
+        ],
+    }
+    p = Profile.from_dict(raw)
+    assert [m.color_management for m in p.monitors] == [
+        "hdr", "", "srgb", "hdr",
+    ]


### PR DESCRIPTION
Fixes #41 

## Changes

### 1. Show "inactive" subtitle hint on HDR-dependent settings when CM isn't HDR-capable

Controls under the HDR/EDID Override group (SDR EOTF, luminance fields, etc.) as well as some other settings only affect the visual output when Color Management is set to `hdr` or `hdredid`. When CM is set to any other value, these rows now show an `"inactive"` subtitle with a tooltip explaining the settings may not apply — while remaining fully modifiable. (Hyprland's auto HDR setting can still make them relevant.)

<img width="1768" height="1086" alt="image" src="https://github.com/user-attachments/assets/9e6436b2-4302-44b6-8f95-767d746897dc" />



- **properties_panel.py** — Added `_hdr_dependent_rows` list collecting relevant widgets
- **properties_panel.py** — Added `_hdr_dependent_settings_hints` sync method that sets subtitle + tooltip on each row
- Syncs on profile load (`update_from_monitor`) and on every property change (`_on_changed`

### 2. Remove standalone HDR toggle

`color_management = "hdr"` already produces the same config output as the old `hdr: true` toggle. The standalone switch (`_sw_hdr`) was redundant with the Color Management dropdown and potentially confusing.

- **models.py** — Removed `hdr: bool` from `MonitorConfig`
- **models.py** — Simplified config output: `cm = self.color_management` (removed the `("hdr" if self.hdr else "")` fallback in both legacy and Lua paths)
- **models.py** — Added legacy migration in `Profile.from_dict`: profiles with `"hdr": true` and no explicit CM are auto-converted to `color_management: "hdr"` on load
- **properties_panel.py** — Removed `_sw_hdr` widget creation, `set_active`, and `get_active`

## Tests

Added `tests/test_hdr_migration.py` covering:

- Legacy `hdr: true` without CM → `color_management: "hdr"`
- Explicit CM takes priority over `hdr: true`
- No `hdr` key → unchanged
- `hdr: false` → unchanged
- Round-trip preserves migrated value, `hdr` not present in serialized output
- Multiple monitors migrate independently



---
This was chosen as an alternative to the solution offered in #43 due to the presence of hyprland config like `cm_auto_hdr` which automatically changes color management profile to hdr when in fullscreen application. Thus, full dimming felt to intrusive. Thus this offers an alternative solution to #43.