### PR TITLE
feat(config): configurable monitor config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - **Confirm-or-revert** — 10-second countdown after applying, auto-reverts if display is unusable
 - **CLI interface** — list, query, and switch profiles from the terminal (`--list-profiles`, `--current-profile`, `--switch-profile`), perfect for hotkey bindings
 - **Custom config directory** — write generated monitor config files to a custom path instead of the compositor default (via Preferences or `--config-dir`)
+- **Custom config filename** — change the generated file's base name (default `monitors`) from **Preferences → Config Output**; the right extension is added per compositor (`.kdl`/`.conf`/`.lua`) and subdirectories are supported (e.g. `cfg/display`)
 - **Active profile tracking** — the last applied profile is persisted across GUI, CLI, and daemon, queryable via `--current-profile`
 
 ## Installation
@@ -263,6 +264,14 @@ leaves the previously generated file on disk: delete it, or drop its `source`/`r
 line from your Hyprland config, otherwise Hyprland keeps applying the stale layout.
 
 To use a custom output directory, set it in **Preferences → Config Output** or pass `--config-dir` on the command line.
+
+To change the generated file's base name (default `monitors`), set **Monitor config filename** in
+**Preferences → Config Output** (stored as `monitor_config_name` in `settings.json`). The value is a
+base name without extension, relative to the compositor's config directory, and may include
+subdirectories (e.g. `cfg/display` → `cfg/display.kdl` for Niri, `cfg/display.conf` for Sway, and
+`cfg/display.conf`/`cfg/display.lua` for Hyprland). Absolute paths and `..` segments are rejected.
+For Niri, the `include` line in `config.kdl` is kept in sync with the configured name; if you change
+the name later, update your Hyprland `source`/`require` lines to match.
 
 ## Project structure
 

--- a/src/monique/config_paths.py
+++ b/src/monique/config_paths.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from .hypr_config import hyprland_config_paths
 from .utils import (
+    get_monitor_config_name,
     is_hyprland_installed,
     is_niri_installed,
     is_sway_installed,
@@ -28,12 +29,12 @@ NIRI = "niri"
 
 def sway_monitors_path() -> Path:
     """Return the Sway monitor config file."""
-    return sway_config_dir() / "monitors.conf"
+    return sway_config_dir() / f"{get_monitor_config_name()}.conf"
 
 
 def niri_monitors_path() -> Path:
     """Return the Niri monitor config file."""
-    return niri_config_dir() / "monitors.kdl"
+    return niri_config_dir() / f"{get_monitor_config_name()}.kdl"
 
 
 def compositor_config_paths(

--- a/src/monique/hypr_config.py
+++ b/src/monique/hypr_config.py
@@ -22,6 +22,7 @@ from .utils import (
     HYPR_FORMAT_LUA,
     backup_file,
     get_hypr_config_format,
+    get_monitor_config_name,
     hyprland_config_dir,
     normalize_hypr_format,
     write_text,
@@ -37,11 +38,12 @@ def hyprland_config_paths(fmt: str | None = None) -> list[Path]:
     """Return the Hyprland monitor config files written for *fmt*."""
     fmt = _resolve_format(fmt)
     conf_dir = hyprland_config_dir()
+    name = get_monitor_config_name()
     paths: list[Path] = []
     if fmt in (HYPR_FORMAT_LEGACY, HYPR_FORMAT_BOTH):
-        paths.append(conf_dir / "monitors.conf")
+        paths.append(conf_dir / f"{name}.conf")
     if fmt in (HYPR_FORMAT_LUA, HYPR_FORMAT_BOTH):
-        paths.append(conf_dir / "monitors.lua")
+        paths.append(conf_dir / f"{name}.lua")
     return paths
 
 
@@ -56,10 +58,11 @@ def write_hyprland_configs(
     """Back up and write the Hyprland monitor configs, returning the paths written."""
     fmt = _resolve_format(fmt)
     conf_dir = hyprland_config_dir()
+    name = get_monitor_config_name()
     written: list[Path] = []
 
     if fmt in (HYPR_FORMAT_LEGACY, HYPR_FORMAT_BOTH):
-        monitors_conf = conf_dir / "monitors.conf"
+        monitors_conf = conf_dir / f"{name}.conf"
         backup_file(monitors_conf)
         write_text(monitors_conf, profile.generate_config(
             use_description=use_description,
@@ -69,7 +72,7 @@ def write_hyprland_configs(
         written.append(monitors_conf)
 
     if fmt in (HYPR_FORMAT_LUA, HYPR_FORMAT_BOTH):
-        monitors_lua = conf_dir / "monitors.lua"
+        monitors_lua = conf_dir / f"{name}.lua"
         backup_file(monitors_lua)
         write_text(monitors_lua, profile.generate_lua_config(
             use_description=use_description,

--- a/src/monique/hyprland.py
+++ b/src/monique/hyprland.py
@@ -8,15 +8,18 @@ import socket
 from pathlib import Path
 from typing import AsyncIterator
 
-from .config_paths import HYPRLAND, compositor_config_paths
+from .config_paths import (
+    HYPRLAND,
+    compositor_config_paths,
+    niri_monitors_path,
+    sway_monitors_path,
+)
 from .hypr_config import write_hyprland_configs
 from .models import MonitorConfig, Profile, WorkspaceRule
 from .utils import (
     hyprland_runtime_dir,
     is_sway_installed,
-    sway_config_dir,
     is_niri_installed,
-    niri_config_dir,
     is_sddm_running,
     is_greetd_running,
     write_xsetup,
@@ -210,13 +213,13 @@ class HyprlandIPC:
 
         # Also write Sway config if Sway is installed
         if is_sway_installed():
-            sway_conf = sway_config_dir() / "monitors.conf"
+            sway_conf = sway_monitors_path()
             backup_file(sway_conf)
             write_text(sway_conf, profile.generate_sway_config(use_description=use_description))
 
         # Also write Niri config if Niri is installed
         if is_niri_installed():
-            niri_conf = niri_config_dir() / "monitors.kdl"
+            niri_conf = niri_monitors_path()
             backup_file(niri_conf)
             write_text(niri_conf, profile.generate_niri_config(use_description=use_description))
 

--- a/src/monique/niri.py
+++ b/src/monique/niri.py
@@ -5,18 +5,24 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import socket
 from pathlib import Path
 from typing import AsyncIterator
 
-from .config_paths import NIRI, compositor_config_paths, niri_monitors_path
+from .config_paths import (
+    NIRI,
+    compositor_config_paths,
+    niri_monitors_path,
+    sway_monitors_path,
+)
 from .hypr_config import write_hyprland_configs
 from .models import MonitorConfig, Profile, focus_at_startup_from_niri
 from .utils import (
     niri_config_dir,
+    get_monitor_config_name,
     is_hyprland_installed,
     is_sway_installed,
-    sway_config_dir,
     is_sddm_running,
     is_greetd_running,
     write_xsetup,
@@ -38,12 +44,69 @@ def read_focus_at_startup() -> list[str]:
     return focus_at_startup_from_niri(conf.read_text(encoding="utf-8"))
 
 
-def _ensure_niri_config_include() -> bool:
-    """Ensure config.kdl includes monitors.kdl, removing inline output blocks.
+# Comment marker written above the Monique-managed ``include`` line in
+# config.kdl.  It is how we tell our own include apart from a user's when the
+# configured filename changes and the stale line has to be swapped out.
+_NIRI_INCLUDE_MARKER = "// Monique monitor configuration"
 
-    On first run, strips any top-level ``output`` blocks from config.kdl
-    (since Monique now manages them via monitors.kdl) and appends the
-    ``include`` directive.  Subsequent calls are no-ops.
+
+def _strip_monique_include(lines: list[str]) -> tuple[list[str], str | None]:
+    """Drop the Monique-managed marker + ``include`` line.
+
+    Returns the remaining lines and the previous include target (the quoted
+    filename), or ``None`` when no Monique-managed include was present.  User
+    ``include`` lines (which lack the marker) are left untouched.
+    """
+    kept: list[str] = []
+    old_target: str | None = None
+    i = 0
+    n = len(lines)
+    while i < n:
+        if lines[i].strip() == _NIRI_INCLUDE_MARKER:
+            j = i + 1
+            while j < n and lines[j].strip() == "":
+                j += 1
+            if j < n and lines[j].lstrip().startswith("include"):
+                m = re.search(r'"([^"]+)"', lines[j])
+                if m:
+                    old_target = m.group(1)
+                j += 1
+            i = j
+            continue
+        kept.append(lines[i])
+        i += 1
+    return kept, old_target
+
+
+def _strip_niri_output_blocks(lines: list[str]) -> list[str]:
+    """Remove top-level ``output "..." { ... }`` blocks (Monique manages them)."""
+    cleaned: list[str] = []
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("output ") and "{" in stripped:
+            depth = stripped.count("{") - stripped.count("}")
+            i += 1
+            while i < len(lines) and depth > 0:
+                depth += lines[i].count("{") - lines[i].count("}")
+                i += 1
+            if i < len(lines) and lines[i].strip() == "":
+                i += 1
+            continue
+        cleaned.append(lines[i])
+        i += 1
+    return cleaned
+
+
+def _ensure_niri_config_include() -> bool:
+    """Ensure config.kdl includes the configured monitor config file.
+
+    On first run, strips any top-level ``output`` blocks from config.kdl (since
+    Monique now manages them via the include) and appends the ``include``
+    directive.  When the configured filename has changed since a previous run,
+    the stale Monique-managed ``include`` is removed and replaced so Niri never
+    applies two conflicting layouts.  A user's own ``include`` of the current
+    file is respected and never duplicated.
 
     Returns True if config.kdl was modified.
     """
@@ -55,43 +118,33 @@ def _ensure_niri_config_include() -> bool:
     except OSError:
         return False
 
-    # Check if include already present
-    has_include = False
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("//"):
-            continue
-        if "include" in stripped and "monitors.kdl" in stripped:
-            has_include = True
-            break
+    rel_name = f"{get_monitor_config_name()}.kdl"
+    lines = text.splitlines(keepends=True)
 
-    if has_include:
+    kept, old_target = _strip_monique_include(lines)
+    first_run = old_target is None
+
+    # A user-authored include of the current file (no Monique marker) counts as
+    # already present: don't add a second one.
+    user_has_current = any(
+        not ln.lstrip().startswith("//") and "include" in ln and rel_name in ln
+        for ln in kept
+    )
+
+    # Our include already targets the right file, or the user manages it: no-op.
+    if old_target == rel_name or (first_run and user_has_current):
         return False
 
-    # Strip top-level output blocks: ``output "..." { ... }``
-    lines = text.splitlines(keepends=True)
-    cleaned: list[str] = []
-    i = 0
-    while i < len(lines):
-        stripped = lines[i].strip()
-        if stripped.startswith("output ") and "{" in stripped:
-            # Skip until closing brace
-            depth = stripped.count("{") - stripped.count("}")
-            i += 1
-            while i < len(lines) and depth > 0:
-                depth += lines[i].count("{") - lines[i].count("}")
-                i += 1
-            # Skip trailing blank line after block
-            if i < len(lines) and lines[i].strip() == "":
-                i += 1
-            continue
-        cleaned.append(lines[i])
-        i += 1
+    # Only strip output blocks on a genuine first run; on a rename the user may
+    # have legitimately re-added output blocks we must not touch.
+    if first_run:
+        kept = _strip_niri_output_blocks(kept)
 
-    result = "".join(cleaned)
-    if not result.endswith("\n"):
+    result = "".join(kept).rstrip("\n")
+    if user_has_current:
         result += "\n"
-    result += '\n// Monique monitor configuration\ninclude "monitors.kdl"\n'
+    else:
+        result += f'\n\n{_NIRI_INCLUDE_MARKER}\ninclude "{rel_name}"\n'
 
     backup_file(config)
     write_text(config, result)
@@ -161,9 +214,8 @@ class NiriIPC:
         update_greetd: bool = True, use_description: bool = False,
         hypr_config_format: str | None = None,
     ) -> None:
-        """Write monitors.kdl (Niri auto-reloads) and cross-write other compositors."""
-        conf_dir = niri_config_dir()
-        monitors_conf = conf_dir / "monitors.kdl"
+        """Write the Niri monitor config (auto-reloads) and cross-write others."""
+        monitors_conf = niri_monitors_path()
 
         # Build mapping: normalised description → Niri-native description
         # so that output identifiers in the KDL config match what Niri expects
@@ -208,7 +260,7 @@ class NiriIPC:
 
         # Cross-write Sway config if Sway is installed
         if is_sway_installed():
-            sway_conf = sway_config_dir() / "monitors.conf"
+            sway_conf = sway_monitors_path()
             backup_file(sway_conf)
             write_text(sway_conf, profile.generate_sway_config(use_description=use_description))
 

--- a/src/monique/sway.py
+++ b/src/monique/sway.py
@@ -10,14 +10,17 @@ import struct
 from pathlib import Path
 from typing import AsyncIterator
 
-from .config_paths import SWAY, compositor_config_paths
+from .config_paths import (
+    SWAY,
+    compositor_config_paths,
+    niri_monitors_path,
+    sway_monitors_path,
+)
 from .hypr_config import write_hyprland_configs
 from .models import MonitorConfig, Profile
 from .utils import (
     is_hyprland_installed,
-    sway_config_dir,
     is_niri_installed,
-    niri_config_dir,
     is_sddm_running,
     is_greetd_running,
     write_xsetup,
@@ -115,8 +118,7 @@ class SwayIPC:
         hypr_config_format: str | None = None,
     ) -> None:
         """Write monitor config and reload Sway."""
-        conf_dir = sway_config_dir()
-        monitors_conf = conf_dir / "monitors.conf"
+        monitors_conf = sway_monitors_path()
 
         # Backup existing
         backup_file(monitors_conf)
@@ -132,7 +134,7 @@ class SwayIPC:
 
         # Also write Niri config if Niri is installed
         if is_niri_installed():
-            niri_conf = niri_config_dir() / "monitors.kdl"
+            niri_conf = niri_monitors_path()
             backup_file(niri_conf)
             write_text(niri_conf, profile.generate_niri_config(use_description=use_description))
 

--- a/src/monique/utils.py
+++ b/src/monique/utils.py
@@ -20,6 +20,12 @@ HYPR_FORMATS = (HYPR_FORMAT_LEGACY, HYPR_FORMAT_LUA, HYPR_FORMAT_BOTH)
 # Default retrocompatibile: scrive entrambi i file, come prima dell'opzione
 DEFAULT_HYPR_FORMAT = HYPR_FORMAT_BOTH
 
+# Base name (senza estensione) dei file di config monitor generati.  L'estensione
+# la aggiunge ogni compositore: ``.kdl`` (Niri), ``.conf`` (Sway/Hyprland legacy),
+# ``.lua`` (Hyprland >= 0.55).  Può includere sottocartelle relative alla config
+# dir del compositore (es. ``cfg/display``).  Il default riproduce i nomi storici.
+DEFAULT_MONITOR_CONFIG_NAME = "monitors"
+
 # Override runtime impostato via --config-dir (priorità su settings.json)
 _runtime_config_dir: str | None = None
 
@@ -210,6 +216,53 @@ def normalize_hypr_format(value: object) -> str:
 def get_hypr_config_format() -> str:
     """Return the Hyprland config format selected in the app settings."""
     return normalize_hypr_format(load_app_settings().get("hypr_config_format"))
+
+
+# Estensioni note che l'utente potrebbe digitare per errore nel base name:
+# le rimuoviamo così che ``display.kdl`` non diventi ``display.kdl.conf``.
+_MONITOR_CONFIG_EXTS = (".kdl", ".conf", ".lua")
+
+
+def sanitize_monitor_config_name(value: object) -> str:
+    """Return a safe relative stem for the monitor config files.
+
+    Accetta un percorso relativo (eventualmente con sottocartelle) e lo riduce a
+    un base name sicuro:
+
+    - i separatori vengono normalizzati a ``/`` (POSIX), come si scrivono nei
+      config di Niri/Hyprland;
+    - un'estensione nota digitata per errore (``.kdl``/``.conf``/``.lua``) viene
+      rimossa: l'estensione la aggiunge il compositore;
+    - percorsi assoluti, segmenti ``..``, ``.`` e componenti vuoti vengono
+      rifiutati (niente traversal fuori dalla config dir);
+    - se il risultato è vuoto o non valido si ricade sul default ``monitors``.
+    """
+    if not isinstance(value, str):
+        return DEFAULT_MONITOR_CONFIG_NAME
+
+    raw = value.strip().replace("\\", "/")
+    if not raw or raw.startswith("/"):
+        return DEFAULT_MONITOR_CONFIG_NAME
+
+    # Rimuove un'estensione nota digitata per errore (solo sull'ultimo segmento).
+    lowered = raw.lower()
+    for ext in _MONITOR_CONFIG_EXTS:
+        if lowered.endswith(ext):
+            raw = raw[: -len(ext)]
+            break
+
+    parts = [p for p in raw.split("/") if p not in ("", ".")]
+    if not parts or any(p == ".." for p in parts):
+        return DEFAULT_MONITOR_CONFIG_NAME
+
+    return "/".join(parts)
+
+
+def get_monitor_config_name() -> str:
+    """Return the sanitized monitor config base name from the app settings."""
+    return sanitize_monitor_config_name(
+        load_app_settings().get("monitor_config_name")
+    )
 
 
 def save_active_profile(name: str | None) -> None:

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -20,7 +20,9 @@ from .utils import (
     HYPR_FORMAT_BOTH,
     HYPR_FORMAT_LEGACY,
     HYPR_FORMAT_LUA,
+    DEFAULT_MONITOR_CONFIG_NAME,
     normalize_hypr_format,
+    sanitize_monitor_config_name,
     backup_file,
     restore_backup,
     is_hyprland_installed,
@@ -399,6 +401,15 @@ class MainWindow(Adw.ApplicationWindow):
         entry_config_dir.connect("changed", self._on_config_dir_changed)
         grp_out.add(entry_config_dir)
 
+        entry_config_name = Adw.EntryRow(
+            title="Monitor config filename (no extension)",
+        )
+        entry_config_name.set_text(
+            self._app_settings.get("monitor_config_name", "")
+        )
+        entry_config_name.connect("changed", self._on_config_name_changed)
+        grp_out.add(entry_config_name)
+
         # ── Hyprland config format group ──
         if is_hyprland_installed():
             grp_hypr = Adw.PreferencesGroup(
@@ -550,6 +561,25 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             self._app_settings.pop("config_dir", None)
         save_app_settings(self._app_settings)
+
+    def _on_config_name_changed(self, row: Adw.EntryRow) -> None:
+        """Handle the monitor config filename entry change in preferences.
+
+        Empty (or a value equal to the default) means "use the built-in name",
+        so we drop the key entirely.  Otherwise store the raw text; it is
+        sanitized on read via ``get_monitor_config_name``.  The effective name
+        is shown as the subtitle so the user sees traversal/extension stripping.
+        """
+        text = row.get_text().strip()
+        effective = sanitize_monitor_config_name(text)
+        if not text or effective == DEFAULT_MONITOR_CONFIG_NAME:
+            self._app_settings.pop("monitor_config_name", None)
+        else:
+            self._app_settings["monitor_config_name"] = text
+        save_app_settings(self._app_settings)
+        row.set_subtitle(
+            f"Files: {effective}.kdl / {effective}.conf / {effective}.lua"
+        )
 
     def _on_clamshell_switch_changed(self, row: Adw.SwitchRow, pspec) -> None:
         """Handle the clamshell mode switch toggle in preferences."""

--- a/src/monique/window.py
+++ b/src/monique/window.py
@@ -390,7 +390,11 @@ class MainWindow(Adw.ApplicationWindow):
         # ── Output Directory group ──
         grp_out = Adw.PreferencesGroup(
             title="Config Output",
-            description="Where generated monitor config files are written (leave empty for compositor default)",
+            description=(
+                "Where generated monitor config files are written. The filename is "
+                "a base name (no extension), relative to the compositor's config "
+                "directory; leave empty for the compositor default."
+            ),
         )
         page.add(grp_out)
 
@@ -406,6 +410,13 @@ class MainWindow(Adw.ApplicationWindow):
         )
         entry_config_name.set_text(
             self._app_settings.get("monitor_config_name", "")
+        )
+        # Adw.EntryRow has no subtitle; the live filename preview goes in the
+        # tooltip, updated on every change.
+        entry_config_name.set_tooltip_text(
+            self._config_name_tooltip(
+                self._app_settings.get("monitor_config_name", "")
+            )
         )
         entry_config_name.connect("changed", self._on_config_name_changed)
         grp_out.add(entry_config_name)
@@ -562,13 +573,27 @@ class MainWindow(Adw.ApplicationWindow):
             self._app_settings.pop("config_dir", None)
         save_app_settings(self._app_settings)
 
+    @staticmethod
+    def _config_name_tooltip(raw: str) -> str:
+        """Build the live filename-preview tooltip for the config-name row.
+
+        Shows the effective files after sanitizing, so the user sees any
+        traversal/extension stripping applied to what they typed.
+        """
+        effective = sanitize_monitor_config_name(raw)
+        return (
+            "Relative to the compositor config directory.\n"
+            f"Files: {effective}.kdl (Niri), {effective}.conf (Sway/Hyprland), "
+            f"{effective}.lua (Hyprland Lua)"
+        )
+
     def _on_config_name_changed(self, row: Adw.EntryRow) -> None:
         """Handle the monitor config filename entry change in preferences.
 
         Empty (or a value equal to the default) means "use the built-in name",
         so we drop the key entirely.  Otherwise store the raw text; it is
         sanitized on read via ``get_monitor_config_name``.  The effective name
-        is shown as the subtitle so the user sees traversal/extension stripping.
+        is shown in the tooltip so the user sees traversal/extension stripping.
         """
         text = row.get_text().strip()
         effective = sanitize_monitor_config_name(text)
@@ -577,9 +602,7 @@ class MainWindow(Adw.ApplicationWindow):
         else:
             self._app_settings["monitor_config_name"] = text
         save_app_settings(self._app_settings)
-        row.set_subtitle(
-            f"Files: {effective}.kdl / {effective}.conf / {effective}.lua"
-        )
+        row.set_tooltip_text(self._config_name_tooltip(text))
 
     def _on_clamshell_switch_changed(self, row: Adw.SwitchRow, pspec) -> None:
         """Handle the clamshell mode switch toggle in preferences."""

--- a/tests/test_config_name.py
+++ b/tests/test_config_name.py
@@ -1,0 +1,198 @@
+"""Tests for the configurable monitor config filename (issue #40).
+
+A single ``monitor_config_name`` setting drives the base name of the files
+written for every compositor; each backend appends its own extension
+(``.kdl`` / ``.conf`` / ``.lua``).  The default reproduces the historical
+``monitors.*`` names so existing setups keep working untouched.
+
+These modules import no ``gi``, matching the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from monique import config_paths, hypr_config, niri
+from monique.utils import (
+    DEFAULT_MONITOR_CONFIG_NAME,
+    get_monitor_config_name,
+    hyprland_config_dir,
+    niri_config_dir,
+    sanitize_monitor_config_name,
+    save_app_settings,
+)
+
+
+# ── sanitize_monitor_config_name ─────────────────────────────────────────
+
+@pytest.mark.parametrize("value", ["", "   ", None, 123, "/abs/path", "..", "a/../b"])
+def test_sanitize_rejects_invalid(value: object) -> None:
+    """Empty, non-string, absolute, and traversal inputs fall back to default."""
+    assert sanitize_monitor_config_name(value) == DEFAULT_MONITOR_CONFIG_NAME
+
+
+def test_sanitize_plain_name() -> None:
+    assert sanitize_monitor_config_name("display") == "display"
+
+
+def test_sanitize_preserves_subdirectory() -> None:
+    assert sanitize_monitor_config_name("cfg/display") == "cfg/display"
+
+
+def test_sanitize_strips_typed_extension() -> None:
+    """A known extension typed by mistake must not be doubled on write."""
+    assert sanitize_monitor_config_name("display.kdl") == "display"
+    assert sanitize_monitor_config_name("cfg/display.CONF") == "cfg/display"
+    assert sanitize_monitor_config_name("display.lua") == "display"
+
+
+def test_sanitize_normalizes_backslashes_and_dot_segments() -> None:
+    assert sanitize_monitor_config_name("cfg\\display") == "cfg/display"
+    assert sanitize_monitor_config_name("./cfg//display") == "cfg/display"
+
+
+# ── get_monitor_config_name (reads settings) ─────────────────────────────
+
+def test_get_defaults_when_unset() -> None:
+    assert get_monitor_config_name() == DEFAULT_MONITOR_CONFIG_NAME
+
+
+def test_get_reads_and_sanitizes_setting() -> None:
+    save_app_settings({"monitor_config_name": "cfg/display.kdl"})
+    assert get_monitor_config_name() == "cfg/display"
+
+
+# ── propagation into the config path source of truth ─────────────────────
+
+def test_default_paths_match_historical_names() -> None:
+    """Back-compat: unset setting reproduces the old filenames exactly."""
+    assert config_paths.niri_monitors_path().name == "monitors.kdl"
+    assert config_paths.sway_monitors_path().name == "monitors.conf"
+    assert [p.name for p in hypr_config.hyprland_config_paths("both")] == [
+        "monitors.conf", "monitors.lua",
+    ]
+
+
+def test_custom_name_propagates_to_all_backends() -> None:
+    save_app_settings({"monitor_config_name": "display"})
+
+    assert config_paths.niri_monitors_path() == niri_config_dir() / "display.kdl"
+    assert config_paths.sway_monitors_path().name == "display.conf"
+    assert [p.name for p in hypr_config.hyprland_config_paths("both")] == [
+        "display.conf", "display.lua",
+    ]
+
+
+def test_custom_subdirectory_propagates() -> None:
+    save_app_settings({"monitor_config_name": "cfg/display"})
+
+    niri_path = config_paths.niri_monitors_path()
+    assert niri_path == niri_config_dir() / "cfg" / "display.kdl"
+    assert config_paths.sway_monitors_path() == \
+        config_paths.sway_config_dir() / "cfg" / "display.conf"
+    assert hypr_config.hyprland_config_paths("lua")[0] == \
+        hyprland_config_dir() / "cfg" / "display.lua"
+
+
+# ── Niri include line stays in sync with the configured name ─────────────
+
+def test_niri_include_uses_configured_name() -> None:
+    save_app_settings({"monitor_config_name": "cfg/display"})
+    conf_dir = niri_config_dir()
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    (conf_dir / "config.kdl").write_text("// user config\n", encoding="utf-8")
+
+    changed = niri._ensure_niri_config_include()
+
+    assert changed is True
+    text = (conf_dir / "config.kdl").read_text(encoding="utf-8")
+    assert 'include "cfg/display.kdl"' in text
+    assert "monitors.kdl" not in text
+
+
+def test_niri_include_detected_when_already_present() -> None:
+    save_app_settings({"monitor_config_name": "display"})
+    conf_dir = niri_config_dir()
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    # A user-authored include of the current file (no Monique marker).
+    (conf_dir / "config.kdl").write_text(
+        'include "display.kdl"\n', encoding="utf-8"
+    )
+
+    # Already includes the configured file: no rewrite.
+    assert niri._ensure_niri_config_include() is False
+
+
+def test_niri_include_noop_when_marker_already_current() -> None:
+    save_app_settings({"monitor_config_name": "display"})
+    conf_dir = niri_config_dir()
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    (conf_dir / "config.kdl").write_text(
+        '// Monique monitor configuration\ninclude "display.kdl"\n',
+        encoding="utf-8",
+    )
+
+    assert niri._ensure_niri_config_include() is False
+
+
+def test_niri_include_swaps_stale_name_on_rename() -> None:
+    """Renaming the config file removes the stale Monique include, not the user's."""
+    conf_dir = niri_config_dir()
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    (conf_dir / "config.kdl").write_text(
+        'include "keep-me.kdl"\n'
+        '\n// Monique monitor configuration\ninclude "monitors.kdl"\n',
+        encoding="utf-8",
+    )
+
+    save_app_settings({"monitor_config_name": "cfg/display"})
+    changed = niri._ensure_niri_config_include()
+
+    text = (conf_dir / "config.kdl").read_text(encoding="utf-8")
+    assert changed is True
+    # New name in, stale name out.
+    assert 'include "cfg/display.kdl"' in text
+    assert "monitors.kdl" not in text
+    # User's unrelated include is preserved.
+    assert 'include "keep-me.kdl"' in text
+    # Exactly one Monique marker remains.
+    assert text.count("// Monique monitor configuration") == 1
+
+
+def test_niri_include_rename_keeps_user_output_blocks() -> None:
+    """On a rename (not first run), user-added output blocks must survive."""
+    conf_dir = niri_config_dir()
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    (conf_dir / "config.kdl").write_text(
+        'output "DP-1" {\n    scale 2\n}\n'
+        '\n// Monique monitor configuration\ninclude "monitors.kdl"\n',
+        encoding="utf-8",
+    )
+
+    save_app_settings({"monitor_config_name": "display"})
+    changed = niri._ensure_niri_config_include()
+
+    text = (conf_dir / "config.kdl").read_text(encoding="utf-8")
+    assert changed is True
+    assert 'output "DP-1"' in text  # not stripped on rename
+    assert 'include "display.kdl"' in text
+    assert "monitors.kdl" not in text
+
+
+def test_niri_include_strips_output_blocks_on_first_run() -> None:
+    """True first run (no prior Monique include) still strips output blocks."""
+    save_app_settings({"monitor_config_name": "display"})
+    conf_dir = niri_config_dir()
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    (conf_dir / "config.kdl").write_text(
+        'output "DP-1" {\n    scale 2\n}\n\ninput {\n    keyboard {}\n}\n',
+        encoding="utf-8",
+    )
+
+    changed = niri._ensure_niri_config_include()
+
+    text = (conf_dir / "config.kdl").read_text(encoding="utf-8")
+    assert changed is True
+    assert 'output "DP-1"' not in text  # stripped on first run
+    assert "input {" in text  # unrelated block kept
+    assert 'include "display.kdl"' in text


### PR DESCRIPTION
Closes #40.

## Summary

The generated monitor config filename was hardcoded per compositor (`monitors.kdl` / `monitors.conf` / `monitors.lua`). This adds a single `monitor_config_name` setting: a **base name without extension**, relative to the compositor's config directory, that drives all three backends. Each backend appends its own extension.

Example with `monitor_config_name = "cfg/display"`:

| Compositor | File(s) written |
|-----------|-----------------|
| Niri | `~/.config/niri/cfg/display.kdl` |
| Sway | `~/.config/sway/cfg/display.conf` |
| Hyprland | `~/.config/hypr/cfg/display.conf` and/or `cfg/display.lua` |

The default is `monitors`, reproducing the historical filenames, so **existing setups are untouched** after upgrading.

## Design

Per the discussion on #40, this is one setting covering Niri, Hyprland and Sway rather than a Niri-only option, with the value taken as a path relative to the compositor config directory.

- **Validation** (`utils.sanitize_monitor_config_name`): rejects absolute paths and `..` traversal, normalizes separators, drops a mistakenly typed known extension (`display.kdl` won't become `display.kdl.conf`), and falls back to the default on invalid input. Subdirectories are supported and created on write.
- **Single source of truth**: filename resolution lives in `config_paths` / `hypr_config`, which the GUI already uses for backup/revert, so the written files and the backed-up files can't diverge.
- **Niri include sync**: the `include` line in `config.kdl` uses the configured name. On a **rename**, the stale Monique-managed `include` is swapped out (matched via the `// Monique monitor configuration` marker) so Niri never applies two conflicting layouts — while user `include` lines and user-added `output` blocks are preserved. Output-block stripping still only happens on a true first run.

## UI

New "Monitor config filename (no extension)" row in **Preferences → Config Output**; its subtitle previews the effective filenames.

## Tests

`tests/test_config_name.py` (22 tests): sanitize rules, propagation to all three backends, back-compat with the historical names, and the Niri include cases (first run, rename swap, user-managed include, user output blocks preserved). Full suite: 133 passed.

## Notes

- Renaming on Hyprland still requires updating your `source` / `require` lines by hand (documented in the README), same as the existing config-format switch.
- The privileged greetd path (`/etc/greetd/monique-monitors.conf`) is intentionally out of scope.